### PR TITLE
fix: skills harness probe + log tags + tree expand scroll

### DIFF
--- a/internal/installer/skills.go
+++ b/internal/installer/skills.go
@@ -60,16 +60,50 @@ func (s skillsInstaller) DryRun(t preset.Tool) string { return skillsCommand(t) 
 
 // skillsCommand renders the npx invocation for one skill Tool. Returns
 // empty string when SkillURL is missing — caller treats that as an error.
+//
+// Harness list is resolved LIVE at command-build time (not from the
+// cached probe at TUI startup). Reason: when the user installs codex /
+// opencode in the same run as their skills, detect at TUI startup ran
+// before those CLIs existed and cached an incomplete harness list —
+// the resulting `npx skills add` ran with only `-a claude-code` and
+// the skills never landed in `~/.codex/skills`. Re-probing here picks
+// up the harnesses already installed by earlier steps in this run.
 func skillsCommand(t preset.Tool) string {
 	if t.SkillURL == "" {
 		return ""
 	}
 	parts := []string{"npx", "skills", "add", t.SkillURL,
 		"--skill", t.Name, "-g", "-y", "--copy"}
-	for _, h := range getHarnesses() {
+	harnesses := liveHarnesses()
+	if len(harnesses) == 0 {
+		// Nothing on PATH right now — fall back to cached list (may
+		// have been seeded by detect or by an explicit SetHarnesses
+		// from tests).
+		harnesses = getHarnesses()
+	}
+	for _, h := range harnesses {
 		parts = append(parts, "-a", h)
 	}
 	return strings.Join(parts, " ")
+}
+
+// liveHarnesses probes for AI-harness CLIs on PATH right now. Mirrors
+// the table in internal/detect/detect.go but lives here too to avoid an
+// installer→detect import (detect already imports preset; we keep the
+// dep graph one-way). Keep the lists in sync.
+func liveHarnesses() []string {
+	candidates := []struct{ agent, bin string }{
+		{"claude-code", "claude"},
+		{"codex", "codex"},
+		{"opencode", "opencode"},
+	}
+	var out []string
+	for _, c := range candidates {
+		if _, err := exec.LookPath(c.bin); err == nil {
+			out = append(out, c.agent)
+		}
+	}
+	return out
 }
 
 // SetHarnesses configures the agents the skills backend will pass via

--- a/internal/tui/progress.go
+++ b/internal/tui/progress.go
@@ -217,8 +217,24 @@ func (m progressModel) Update(msg tea.Msg) (progressModel, tea.Cmd) {
 			m.logs = append(m.logs, fmt.Sprintf("%s  %-26s  %s", status, short, suffix))
 		case "stdout", "stderr":
 			if l.Text != "" {
+				// Prefix every stream line with the short tool name so a
+				// fast scan groups output per tool. Without this, a busy
+				// tail mixed mise + node-lts + npm output and the user
+				// couldn't tell which tool emitted which line. Bundle
+				// prefix stripped (`barebones/mise` → `mise`) to keep
+				// the column tight.
 				dot := lipgloss.NewStyle().Foreground(m.palette.Subtle).Render("·")
-				m.logs = append(m.logs, fmt.Sprintf("%s  %s", dot, truncate(l.Text, 60)))
+				tagStyle := lipgloss.NewStyle().Foreground(m.palette.Accent)
+				tag := tagStyle.Render(fmt.Sprintf("%-14s", shortTool(l.Tool)))
+				m.logs = append(m.logs, fmt.Sprintf("%s  %s  %s", dot, tag, truncate(l.Text, 50)))
+			}
+		case "meta":
+			if l.Text != "" {
+				dot := lipgloss.NewStyle().Foreground(m.palette.Subtle).Render("·")
+				tagStyle := lipgloss.NewStyle().Foreground(m.palette.Accent)
+				tag := tagStyle.Render(fmt.Sprintf("%-14s", shortTool(l.Tool)))
+				metaStyle := lipgloss.NewStyle().Foreground(m.palette.Muted).Italic(true)
+				m.logs = append(m.logs, fmt.Sprintf("%s  %s  %s", dot, tag, metaStyle.Render(truncate(l.Text, 50))))
 			}
 		}
 		if len(m.logs) > 8 {
@@ -276,6 +292,23 @@ func truncate(s string, n int) string {
 		return s
 	}
 	return s[:n-1] + "…"
+}
+
+// shortTool strips the bundle prefix off install keys ("barebones/mise"
+// → "mise") and clamps to 14 cols so the per-line task tag stays in a
+// fixed column. Empty input returns "—" so meta lines emitted without
+// a tool (rare) still align.
+func shortTool(s string) string {
+	if s == "" {
+		return "—"
+	}
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		s = s[i+1:]
+	}
+	if len(s) > 14 {
+		s = s[:13] + "…"
+	}
+	return s
 }
 
 func (m progressModel) View(width, height int) string {

--- a/internal/tui/tree_picker.go
+++ b/internal/tui/tree_picker.go
@@ -305,9 +305,27 @@ func (m treePickerModel) findTool(bundleID, toolName string) preset.Tool {
 
 func (m *treePickerModel) expandAtCursor() {
 	row := m.rows[m.cursor]
-	if row.kind == "bundle" {
-		m.expanded[row.bundleID] = true
-		m.rebuildRows()
+	if row.kind != "bundle" {
+		return
+	}
+	m.expanded[row.bundleID] = true
+	m.rebuildRows()
+	// Anchor the bundle to the top of the viewport so its children
+	// scroll into view below it. Without this, expanding the last
+	// bundle on screen leaves the cursor pinned at the bottom and the
+	// user has to manually scroll to see anything they just revealed.
+	m.offset = m.cursor
+	// Move cursor to the first child so the next ↓ press steps through
+	// the expanded contents naturally (mirrors how filesystem tree
+	// pickers in most editors behave).
+	for i := m.cursor + 1; i < len(m.rows); i++ {
+		if m.rows[i].kind == "tool" && m.rows[i].bundleID == row.bundleID {
+			m.cursor = i
+			break
+		}
+	}
+	if m.cursor >= m.offset+m.pageSize {
+		m.offset = m.cursor - m.pageSize + 1
 	}
 }
 


### PR DESCRIPTION
## Summary

- **skills harness probe is now live, not cached.** `npx skills add` was running with the harness list captured at TUI startup. Co-installing codex in the same run meant codex wasn't on PATH at detect time, so the cached list was `[claude-code]` and skills only landed in `~/.claude/skills/` — never reaching `~/.codex/skills/`. Re-probing on every skill install picks up harnesses just installed by earlier steps.
- **per-task tags in the log tail.** Every stdout/stderr/meta line is now prefixed with the short tool name in a fixed 14-col Accent-colored column. A busy install used to mix mise + node-lts + npm output with no way to tell which tool emitted which line.
- **tree expand auto-scroll.** `→` on a bundle now anchors that row to the top of the viewport, snaps cursor to the first child, and clamps offset so expanded contents are visible without manual scroll. Standard tree-picker behavior.

## Test plan

- [ ] `make docker && make docker-shell`
- [ ] `lfg --debug` → pick `node-lts` + `codex` + `agent-browser` → run install
- [ ] After install: `which codex` resolves; `ls ~/.codex/skills/` lists `agent-browser`
- [ ] Tail in progress screen shows `· mise <text>` / `· node-lts <text>` etc., grouped per tool
- [ ] Hit `→` on `SKILLS` bundle row → cursor lands on first skill, all skills visible without manual scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)