### PR TITLE
docs: try starlight-theme-nova

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,7 +1,7 @@
 // @ts-check
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
-import starlightThemeSix from "@six-tech/starlight-theme-six";
+import starlightThemeNova from "starlight-theme-nova";
 
 export default defineConfig({
   // Netlify hosts at the site root (not /lfg/), so no `base` needed.
@@ -9,7 +9,14 @@ export default defineConfig({
   // `site: "https://ptmaroct.github.io"`.
   integrations: [
     starlight({
-      plugins: [starlightThemeSix({})],
+      plugins: [
+        starlightThemeNova({
+          nav: [
+            { label: "Docs", href: "/introduction" },
+            { label: "GitHub", href: "https://github.com/ptmaroct/lfg" },
+          ],
+        }),
+      ],
       title: "lfg",
       description:
         "Open-source TUI bootstrap CLI — make a new dev machine feel like home in minutes.",

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,10 +12,8 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.38.4",
-    "@fontsource/inter": "^5.2.8",
-    "@fontsource/jetbrains-mono": "^5.2.8",
-    "@six-tech/starlight-theme-six": "^1.0.16",
     "astro": "^6.2.1",
-    "sharp": "^0.33.5"
+    "sharp": "^0.33.5",
+    "starlight-theme-nova": "^0.11.9"
   }
 }


### PR DESCRIPTION
Theme experiment — swaps the current \`@six-tech/starlight-theme-six\` for [\`starlight-theme-nova\`](https://starlight-theme-nova.pages.dev/) to compare aesthetics.

## Changes

- Replace \`@six-tech/starlight-theme-six\` with \`starlight-theme-nova\` in deps
- Drop \`@fontsource/inter\` + \`@fontsource/jetbrains-mono\` (Nova handles fonts itself)
- Update \`astro.config.mjs\` import + plugin registration; pass Nova's \`nav\` option for top-bar links to Docs + GitHub

## Test plan

- [ ] Netlify deploy preview renders without errors
- [ ] Compare Nova preview against the current production (Six) deploy
- [ ] If Nova wins: merge here, no further changes needed (Six deps already removed)
- [ ] If Six stays: close this PR

Build verified locally — 23 pages, 26s, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)