### PR TITLE
docs(readme): clean docs link label

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 box — installs the tools you pick, restores your dotfiles, and (soon)
 distributes your SSH identity to the servers you trust.
 
-📖 **Full docs:** <https://lfg-docs.netlify.app>
+📖 **Full docs:** [lfg-docs.netlify.app](https://lfg-docs.netlify.app)
 
 ![welcome](assets/welcome.png)
 


### PR DESCRIPTION
One-line tweak: render the docs link as \`lfg-docs.netlify.app\` instead of \`<https://lfg-docs.netlify.app>\`. Same target, less visual noise.

Repo homepage already set to https://lfg-docs.netlify.app via \`gh repo edit\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)