### PR TITLE
release: enable homebrew tap auto-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@
 #
 # Required secrets / permissions:
 #   - GITHUB_TOKEN        provided automatically; needs `contents: write`
-#   - HOMEBREW_TAP_TOKEN  optional; only when the brews block in
-#                         .goreleaser.yaml is uncommented + the tap repo
-#                         exists at github.com/ptmaroct/homebrew-tap.
+#   - HOMEBREW_TAP_TOKEN  PAT with `contents: write` on
+#                         github.com/ptmaroct/homebrew-tap; goreleaser
+#                         pushes the generated Formula/lfg.rb there.
 
 name: release
 
@@ -39,4 +39,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -67,9 +67,23 @@ changelog:
       - "Merge pull request"
       - "Merge branch"
 
-# Homebrew tap is deferred — install.sh covers macOS + Linux from
-# a single curl one-liner. Re-enable when the tap repo lands at
-# github.com/ptmaroct/homebrew-tap (see docs/release.md if/when added).
+brews:
+  - name: lfg
+    repository:
+      owner: ptmaroct
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: https://github.com/ptmaroct/lfg
+    description: TUI bootstrap CLI for new dev machines
+    license: MIT
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    test: |
+      system "#{bin}/lfg", "version"
+    install: |
+      bin.install "lfg"
 
 release:
   github:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ distributes your SSH identity to the servers you trust.
 
 ## Install
 
+Homebrew (macOS + Linux):
+
+```sh
+brew install ptmaroct/tap/lfg
+```
+
+Or via the curl one-liner:
+
 ```sh
 curl -fsSL https://raw.githubusercontent.com/ptmaroct/lfg/main/install.sh | sh
 ```


### PR DESCRIPTION
## Summary
- Adds `brews:` block to `.goreleaser.yaml` so each tagged release publishes `Formula/lfg.rb` to `ptmaroct/homebrew-tap`
- Uncomments `HOMEBREW_TAP_TOKEN` env in `.github/workflows/release.yml` (secret is already set on the repo)
- Documents `brew install ptmaroct/tap/lfg` as the primary install method in the README

The tap repo (`ptmaroct/homebrew-tap`) and the `HOMEBREW_TAP_TOKEN` repository secret are both in place — merging + cutting the next `v*` tag will publish the formula.

Closes #6.

## Test plan
- [ ] Merge to main
- [ ] `git tag vX.Y.Z && git push --tags`
- [ ] Confirm CI release job is green and `Formula/lfg.rb` lands in `ptmaroct/homebrew-tap`
- [ ] `brew install ptmaroct/tap/lfg && lfg version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)