### PR TITLE
ci: enforce conventional commits via commitlint + local hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# lfg commit-msg hook — enforces Conventional Commits locally.
+#
+# Activated per-clone via `make hooks`, which runs:
+#   git config core.hooksPath .githooks
+#
+# CI runs the full commitlint config (commitlint.config.js) on every
+# PR. This hook is a fast pre-flight regex check — catches the obvious
+# "forgot the type prefix" / "wrote 'Fix:' with a capital" cases before
+# you push.
+
+set -euo pipefail
+
+msg_file="$1"
+header=$(head -n1 "$msg_file")
+
+# Skip merge commits, fixups, reverts produced by `git revert`.
+case "$header" in
+  Merge\ * | "fixup! "* | "squash! "* | "Revert \""*) exit 0 ;;
+esac
+
+# Conventional Commits regex:
+#   type(optional-scope)!?: subject
+# Types intentionally mirror commitlint.config.js + release-please.
+pattern='^(feat|fix|perf|refactor|docs|test|build|ci|chore|style|revert|release)(\([a-z0-9._/-]+\))?!?: .{4,}$'
+
+if ! [[ "$header" =~ $pattern ]]; then
+  printf '\n\033[31m✗ commit message rejected\033[0m\n\n'
+  printf '  Header must follow Conventional Commits:\n'
+  printf '    \033[2m<type>(<optional-scope>)!?: <subject>\033[0m\n\n'
+  printf '  Allowed types: feat, fix, perf, refactor, docs, test,\n'
+  printf '                 build, ci, chore, style, revert, release\n\n'
+  printf '  Got:\n    \033[2m%s\033[0m\n\n' "$header"
+  printf '  Examples:\n'
+  printf '    \033[2mfeat(installer): add support for fish shell rc\033[0m\n'
+  printf '    \033[2mfix: respect XDG_CONFIG_HOME on Linux\033[0m\n'
+  printf '    \033[2mfeat!: drop legacy v0.1 preset format\033[0m\n\n'
+  exit 1
+fi
+
+# Subject (everything after the colon-space) must not end in a period.
+subject="${header#*: }"
+if [[ "$subject" == *. ]]; then
+  printf '\n\033[31m✗ subject ends with a period\033[0m\n'
+  printf '    %s\n\n' "$header"
+  exit 1
+fi
+
+# Subject must start lowercase (matches the PR-title rule in CI).
+first_char="${subject:0:1}"
+if [[ "$first_char" =~ [A-Z] ]]; then
+  printf '\n\033[31m✗ subject must start with a lowercase letter\033[0m\n'
+  printf '    %s\n\n' "$header"
+  exit 1
+fi
+
+exit 0

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,60 @@
+# Lints commits + PR titles against Conventional Commits so
+# release-please can reliably derive version bumps and changelogs.
+#
+# Two jobs:
+#   1. pr-title    — the squash-merge subject is the PR title, so it
+#                    must match Conventional Commits regardless of how
+#                    sloppy the inner commits are.
+#   2. commits     — every commit on a PR is also checked, useful for
+#                    repos that merge with rebase/merge-commit.
+#
+# Rules live in commitlint.config.js at repo root.
+
+name: commitlint
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pr-title:
+    name: PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            test
+            build
+            ci
+            chore
+            style
+            revert
+            release
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" must start with a lowercase letter.
+            Example: "feat: add brew install support"
+
+  commits:
+    name: Commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: commitlint.config.js

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -57,4 +57,4 @@ jobs:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v6
         with:
-          configFile: commitlint.config.js
+          configFile: commitlint.config.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,7 +319,7 @@ Subject must:
 - **not end with a period**
 - describe the change in the imperative ("add", not "added"/"adds")
 
-**Allowed types** (mirrors `commitlint.config.js`):
+**Allowed types** (mirrors `commitlint.config.mjs`):
 `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`,
 `chore`, `style`, `revert`, `release`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ make docker-run      # launch TUI in container
 make docker-shell    # bash inside fresh container, lfg on PATH
 make docker-test     # one-shot: build + auto-run lfg --debug + bash on exit
 make docker-bare     # INCLUDE_BREW=0 — bare ubuntu, exercises brew bootstrap
+make hooks           # one-time: wire .githooks/ for local commit-msg lint
 ```
 
 Single test:
@@ -301,6 +302,58 @@ The agent plan that drove the design lives outside the repo at
 copied to `plan.md` which is gitignored). README has the v0.1 → v1
 roadmap. v0.2 = GitHub auth + remote sync. v0.3 = SSH + macOS defaults.
 Anything not in v0.1 should not land without revisiting that plan.
+
+## Commit messages — Conventional Commits, enforced
+
+**All commits and PR titles must follow Conventional Commits.**
+The `.github/workflows/commitlint.yml` workflow blocks PR merges if
+the title or any commit on the branch fails. The local
+`.githooks/commit-msg` hook (wired via `make hooks`) catches the same
+failures pre-push.
+
+**Format:** `<type>(<optional-scope>)!?: <subject>`
+
+Subject must:
+- start with a **lowercase** letter
+- be ≥4 chars and ≤100 chars
+- **not end with a period**
+- describe the change in the imperative ("add", not "added"/"adds")
+
+**Allowed types** (mirrors `commitlint.config.js`):
+`feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`,
+`chore`, `style`, `revert`, `release`.
+
+**Release-impact mapping** (release-please derives the next version):
+- `feat:` → minor bump
+- `fix:` / `perf:` → patch bump
+- `feat!:` or `BREAKING CHANGE:` footer → major bump (or minor while
+  pre-1.0 because `bump-minor-pre-major` is set)
+- `docs:` / `chore:` / `test:` / `ci:` / `style:` / `build:` /
+  `refactor:` / `release:` → no release triggered
+
+**Good examples:**
+```
+feat(installer): add support for fish shell rc
+fix: respect XDG_CONFIG_HOME on Linux
+docs(readme): document brew install flow
+ci: bump goreleaser-action to v6
+feat!: drop legacy v0.1 preset format
+```
+
+**Common ways to fail the hook:**
+- `Fix bug` → must be `fix: <something>` (lowercase type, colon, scope)
+- `feat: Added new theme` → subject starts uppercase + past tense
+- `feat: add theme.` → trailing period
+- `update README` → no type prefix
+
+**For squash merges** (which is how this repo merges PRs), the **PR
+title** becomes the commit message on `main` — release-please reads
+that, not the inner commits. The `pr-title` job in commitlint.yml
+enforces the same rules on PR titles. So when opening a PR, write the
+title as if it's the final commit message.
+
+**Co-author trailers** (the `Co-Authored-By:` line) and other footers
+are always allowed; the rules apply only to the header line.
 
 ## Release pipeline
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # lfg — build, test, snapshot, demo
-.PHONY: build run test snap snap-update widths demo docker docker-bare docker-run docker-shell docker-test docker-test-bare clean release release-snapshot docs-install docs docs-build
+.PHONY: build run test snap snap-update widths demo docker docker-bare docker-run docker-shell docker-test docker-test-bare clean release release-snapshot docs-install docs docs-build hooks
 
 build:
 	go build -o lfg ./cmd/lfg
@@ -94,3 +94,11 @@ docs:
 
 docs-build:
 	cd docs && npm run build
+
+# One-time per clone: wire .githooks/ as the git hooks directory so the
+# commit-msg conventional-commits check runs locally before push. CI
+# enforces the same rules on PRs via .github/workflows/commitlint.yml.
+hooks:
+	git config core.hooksPath .githooks
+	@echo "git hooks installed → .githooks/"
+	@echo "commit messages will be validated against Conventional Commits."

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,42 @@
+// Conventional Commits config used by both the server-side
+// commitlint GitHub Action and (optionally) any local Node-based
+// pre-commit hook a contributor wires up.
+//
+// Types are aligned with what release-please understands so the
+// stable + beta release flows can derive sensible version bumps.
+//
+// See:
+//   https://www.conventionalcommits.org/
+//   https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat", // user-facing feature → minor bump
+        "fix", // user-facing bug fix → patch bump
+        "perf", // performance improvement → patch bump
+        "refactor", // internal refactor, no behavior change
+        "docs", // documentation only
+        "test", // test changes only
+        "build", // build system, dependencies (go.mod, Dockerfile, Makefile)
+        "ci", // CI config (.github/workflows, goreleaser)
+        "chore", // anything else that doesn't fit
+        "style", // formatting, whitespace, lint fixes
+        "revert", // revert of an earlier commit
+        "release", // release-please / goreleaser machinery commits
+      ],
+    ],
+    // Subject line: at least 4 chars, max 100, no trailing period.
+    "subject-min-length": [2, "always", 4],
+    "subject-max-length": [2, "always", 100],
+    "subject-full-stop": [2, "never", "."],
+    // Header itself capped slightly higher to leave room for a long scope.
+    "header-max-length": [2, "always", 120],
+    // Body & footer line wrapping is a courtesy, not a hard rule.
+    "body-max-line-length": [0],
+    "footer-max-line-length": [0],
+  },
+};

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -8,7 +8,7 @@
 // See:
 //   https://www.conventionalcommits.org/
 //   https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits
-module.exports = {
+export default {
   extends: ["@commitlint/config-conventional"],
   rules: {
     "type-enum": [


### PR DESCRIPTION
## Summary
- Adds CI lint that blocks PR merges if the PR title or any commit on the branch is not a Conventional Commit
- Adds a fast local \`.githooks/commit-msg\` check (no Node deps), opt-in via \`make hooks\`
- Documents the rules + the type → version-bump mapping in CLAUDE.md so contributors and AI agents stop generating commits that fail the hook

## Why this matters now
We just wired release-please. It derives the next version + auto-changelog by parsing Conventional Commits. Without enforcement, one stray \`update README\` commit on main means release-please silently drops a release.

For squash merges (this repo's default), the **PR title** is what lands on main — so PR-title linting is the load-bearing piece. The per-commit lint is a bonus for anyone using rebase/merge-commit flows.

## What CI rejects after this lands
- Missing type prefix: \`update README\` → fail
- Wrong case: \`Fix bug\`, \`feat: Added theme\` → fail
- Trailing period: \`feat: add theme.\` → fail
- Subject too short or too long → fail

## Allowed types
\`feat\`, \`fix\`, \`perf\`, \`refactor\`, \`docs\`, \`test\`, \`build\`, \`ci\`, \`chore\`, \`style\`, \`revert\`, \`release\`

Release-please mapping: \`feat\` → minor, \`fix\`/\`perf\` → patch, \`feat!\` or \`BREAKING CHANGE:\` → major (or minor while pre-1.0). Other types do not trigger releases.

## Test plan
- [ ] PR title \"ci: enforce conventional commits...\" passes the new \`PR title\` check (this PR is the smoke test)
- [ ] Commit messages on this branch pass \`Commit messages\` job
- [ ] After merge, run \`make hooks\` locally and try \`git commit --allow-empty -m 'broken message'\` to confirm the local hook rejects it
- [ ] Try \`git commit --allow-empty -m 'docs: smoke test'\` to confirm valid messages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)