### PR TITLE
docs: add install tabs, json-ld, and pinch-zoom disable

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -123,6 +123,20 @@ export default defineConfig({
   lastUpdated: true,
   sitemap: { hostname: SITE_URL },
   head: [
+    // Viewport — disables pinch zoom across mobile browsers. iOS Safari
+    // ignores `user-scalable=no` since iOS 10, but combining
+    // `maximum-scale=1` with `touch-action: manipulation` (in style.css)
+    // gets the same effect on Safari while remaining a no-op on
+    // Chrome/Firefox where user-scalable=no still works.
+    [
+      "meta",
+      {
+        name: "viewport",
+        content:
+          "width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover",
+      },
+    ],
+
     // Favicons
     ["link", { rel: "icon", type: "image/svg+xml", href: "/favicon.svg" }],
     ["link", { rel: "alternate icon", href: "/favicon.svg" }],
@@ -170,6 +184,38 @@ export default defineConfig({
       },
     ],
     ["style", {}, HERO_CSS],
+
+    // JSON-LD — SoftwareApplication structured data so search engines
+    // and link unfurlers (slack/discord) understand what lfg is.
+    [
+      "script",
+      { type: "application/ld+json" },
+      JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        name: SITE_NAME,
+        alternateName: "lfg",
+        description: SITE_DESCRIPTION,
+        url: SITE_URL,
+        downloadUrl: "https://github.com/ptmaroct/lfg/releases/latest",
+        applicationCategory: "DeveloperApplication",
+        applicationSubCategory: "CLI",
+        operatingSystem: "macOS, Linux",
+        license: "https://github.com/ptmaroct/lfg/blob/main/LICENSE",
+        author: {
+          "@type": "Person",
+          name: "Anuj Sharma",
+          url: "https://anujsh.com",
+        },
+        codeRepository: "https://github.com/ptmaroct/lfg",
+        programmingLanguage: "Go",
+        offers: {
+          "@type": "Offer",
+          price: "0",
+          priceCurrency: "USD",
+        },
+      }),
+    ],
   ],
 
   // Per-page canonical + og:title/description overrides.

--- a/docs/.vitepress/theme/components/InstallTabs.vue
+++ b/docs/.vitepress/theme/components/InstallTabs.vue
@@ -1,0 +1,170 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from "vue";
+
+type Method = {
+  id: string;
+  label: string;
+  blurb: string;
+  cmd: string;
+  follow?: string;
+};
+
+const methods: Method[] = [
+  {
+    id: "brew",
+    label: "brew",
+    blurb: "macOS + Linux · via the official tap",
+    cmd: "brew install ptmaroct/tap/lfg",
+    follow: "lfg",
+  },
+  {
+    id: "curl",
+    label: "curl",
+    blurb: "no Homebrew required · drops into /usr/local/bin or ~/.local/bin",
+    cmd: "curl -fsSL https://raw.githubusercontent.com/ptmaroct/lfg/main/install.sh | sh",
+    follow: "lfg",
+  },
+  {
+    id: "go",
+    label: "go",
+    blurb: "Go 1.25+ · binary lands in $GOBIN",
+    cmd: "go install github.com/ptmaroct/lfg/cmd/lfg@latest",
+    follow: "lfg",
+  },
+];
+
+const active = ref<string>("brew");
+const current = computed(
+  () => methods.find((m) => m.id === active.value) ?? methods[0],
+);
+
+const tablistEl = ref<HTMLElement | null>(null);
+const copied = ref<string | null>(null);
+
+const select = (id: string) => {
+  active.value = id;
+};
+
+const onKeydown = (e: KeyboardEvent) => {
+  const idx = methods.findIndex((m) => m.id === active.value);
+  if (idx < 0) return;
+
+  let next: number | null = null;
+  if (e.key === "ArrowRight") next = (idx + 1) % methods.length;
+  else if (e.key === "ArrowLeft") next = (idx - 1 + methods.length) % methods.length;
+  else if (e.key === "Home") next = 0;
+  else if (e.key === "End") next = methods.length - 1;
+
+  if (next !== null) {
+    e.preventDefault();
+    active.value = methods[next].id;
+    const tab = tablistEl.value?.querySelectorAll<HTMLButtonElement>(
+      "[role=tab]",
+    )[next];
+    tab?.focus();
+  }
+};
+
+const copy = async (text: string, id: string) => {
+  try {
+    await navigator.clipboard.writeText(text);
+    copied.value = id;
+    setTimeout(() => {
+      if (copied.value === id) copied.value = null;
+    }, 1400);
+  } catch {
+    // No clipboard permission — silently fail. Selection still works.
+  }
+};
+
+const primed = ref(false);
+onMounted(() => {
+  // Small tick so the stagger fires after VitePress hydrates
+  requestAnimationFrame(() => {
+    primed.value = true;
+  });
+});
+</script>
+
+<template>
+  <section
+    class="itabs"
+    :class="{ 'itabs--prime': primed }"
+    aria-labelledby="itabs-heading"
+  >
+    <h3 id="itabs-heading" class="itabs__sr">Install lfg</h3>
+
+    <div
+      ref="tablistEl"
+      class="itabs__tabs"
+      role="tablist"
+      aria-label="Installation method"
+      @keydown="onKeydown"
+    >
+      <button
+        v-for="(m, i) in methods"
+        :key="m.id"
+        :id="`itab-${m.id}`"
+        :class="['itabs__tab', { 'is-active': active === m.id }]"
+        :style="{ '--itabs-stagger': `${i * 60}ms` }"
+        role="tab"
+        type="button"
+        :aria-selected="active === m.id"
+        :aria-controls="`itab-panel-${m.id}`"
+        :tabindex="active === m.id ? 0 : -1"
+        @click="select(m.id)"
+      >
+        <span class="itabs__tab-glyph" aria-hidden="true">$</span>
+        <span class="itabs__tab-label">{{ m.label }}</span>
+      </button>
+
+      <span class="itabs__rule" aria-hidden="true" />
+    </div>
+
+    <div
+      :id="`itab-panel-${current.id}`"
+      class="itabs__panel"
+      role="tabpanel"
+      :aria-labelledby="`itab-${current.id}`"
+      :key="current.id"
+    >
+      <div class="itabs__chrome" aria-hidden="true">
+        <span class="itabs__dot itabs__dot--r" />
+        <span class="itabs__dot itabs__dot--y" />
+        <span class="itabs__dot itabs__dot--g" />
+        <span class="itabs__chrome-label">~/ {{ current.id }}</span>
+
+        <button
+          class="itabs__copy"
+          type="button"
+          :aria-label="`Copy ${current.label} install command`"
+          @click="copy(current.cmd, current.id)"
+        >
+          <span v-if="copied === current.id" class="itabs__copy-on">copied</span>
+          <span v-else class="itabs__copy-off">
+            <svg
+              viewBox="0 0 24 24"
+              width="13"
+              height="13"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <rect x="9" y="9" width="11" height="11" rx="2" />
+              <path d="M5 15V5a2 2 0 0 1 2-2h10" />
+            </svg>
+            copy
+          </span>
+        </button>
+      </div>
+
+      <pre class="itabs__pre"><code><span class="itabs__prompt">$</span> <span class="itabs__cmd">{{ current.cmd }}</span><template v-if="current.follow">
+<span class="itabs__prompt">$</span> <span class="itabs__cmd">{{ current.follow }}</span></template></code></pre>
+
+      <p class="itabs__blurb">{{ current.blurb }}</p>
+    </div>
+  </section>
+</template>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -4,6 +4,7 @@ import HowItWorks from "./components/HowItWorks.vue";
 import Step from "./components/Step.vue";
 import HarnessLogos from "./components/HarnessLogos.vue";
 import ScreenFlow from "./components/ScreenFlow.vue";
+import InstallTabs from "./components/InstallTabs.vue";
 import "./style.css";
 
 export default {
@@ -13,5 +14,6 @@ export default {
     app.component("Step", Step);
     app.component("HarnessLogos", HarnessLogos);
     app.component("ScreenFlow", ScreenFlow);
+    app.component("InstallTabs", InstallTabs);
   },
 } satisfies Theme;

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,4 +1,18 @@
 /* ──────────────────────────────────────────────
+   Disable pinch zoom — iOS Safari ignores
+   `user-scalable=no` on the viewport meta since
+   iOS 10. Setting `touch-action: manipulation` on
+   the root element disables pinch-to-zoom while
+   keeping double-tap-to-zoom and tap-to-focus on
+   form inputs (a11y).
+   ────────────────────────────────────────────── */
+
+html,
+body {
+  touch-action: manipulation;
+}
+
+/* ──────────────────────────────────────────────
    Hero CTA icons — book + GitHub mark
    ────────────────────────────────────────────── */
 
@@ -363,4 +377,342 @@
   width: 20px;
   height: 20px;
   flex-shrink: 0;
+}
+
+/* ──────────────────────────────────────────────
+   Install tabs — brew · curl · go selector for
+   the homepage. Mirrors .sflow__dot active glyph
+   (gradient underline) and .hiw-step--prime
+   stagger pattern.
+   ────────────────────────────────────────────── */
+
+.itabs {
+  margin: 1.25rem 0 0.5rem;
+  --itabs-radius: 12px;
+  --itabs-fg: var(--vp-c-text-1);
+  --itabs-fg-muted: var(--vp-c-text-2);
+  --itabs-divider: var(--vp-c-divider);
+  --itabs-panel-bg: var(--vp-c-bg-soft);
+  --itabs-pre-bg: color-mix(in srgb, var(--vp-c-bg) 96%, var(--vp-c-brand-1) 4%);
+}
+.dark .itabs {
+  --itabs-pre-bg: #0c0c14;
+}
+
+.itabs__sr {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Tab strip ------------------------------------------------------- */
+
+.itabs__tabs {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.4rem;
+  position: relative;
+  padding: 0 0 0.65rem;
+  border-bottom: 1px solid var(--itabs-divider);
+  margin-bottom: 0;
+}
+
+.itabs__tab {
+  --tab-stagger-from: 6px;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0.45rem 0.7rem 0.55rem;
+  font: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.45rem;
+  color: var(--itabs-fg-muted);
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.86rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1;
+  border-radius: 8px 8px 0 0;
+  transition:
+    color 160ms ease,
+    background 160ms ease,
+    transform 160ms ease;
+  position: relative;
+}
+.itabs__tab:hover {
+  color: var(--itabs-fg);
+  background: color-mix(in srgb, var(--vp-c-brand-1) 6%, transparent);
+}
+.itabs__tab:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--vp-c-brand-1) 60%, transparent);
+}
+.itabs__tab.is-active {
+  color: var(--itabs-fg);
+}
+
+/* Tab glyph ($) — muted, tabular */
+.itabs__tab-glyph {
+  font-weight: 800;
+  color: color-mix(in srgb, var(--vp-c-brand-1) 60%, var(--itabs-fg-muted));
+  font-variant-numeric: tabular-nums;
+  font-size: 0.78rem;
+  transform: translateY(0.5px);
+}
+.itabs__tab.is-active .itabs__tab-glyph {
+  background: linear-gradient(120deg, #f472b6 0%, #a78bfa 50%, #34d399 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Active gradient underline — overlaps the tab strip's bottom border
+   so it reads as the tab "owning" that segment of the rule. */
+.itabs__tab::after {
+  content: "";
+  position: absolute;
+  left: 0.5rem;
+  right: 0.5rem;
+  bottom: -1px;
+  height: 2px;
+  border-radius: 2px;
+  background: linear-gradient(90deg, #f472b6, #a78bfa, #34d399);
+  opacity: 0;
+  transform: scaleX(0.4);
+  transform-origin: left;
+  transition:
+    opacity 200ms ease,
+    transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+.itabs__tab.is-active::after {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+.itabs__rule {
+  flex: 1;
+  height: 1px;
+  align-self: end;
+  /* The strip's border-bottom already paints the rule. This element
+     is a layout spacer that pushes future content (none currently). */
+}
+
+/* Stagger-in entrance — only after the prime class is set in JS,
+   so SSR/hydration doesn't flash a blank strip. */
+.itabs--prime .itabs__tab {
+  opacity: 0;
+  transform: translateY(var(--tab-stagger-from));
+  animation: itabs-tab-in 360ms cubic-bezier(0.2, 0.8, 0.2, 1) forwards;
+  animation-delay: var(--itabs-stagger, 0ms);
+}
+
+@keyframes itabs-tab-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .itabs--prime .itabs__tab {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+  .itabs__tab::after {
+    transition: opacity 120ms linear;
+    transform: none;
+  }
+}
+
+/* Panel ----------------------------------------------------------- */
+
+.itabs__panel {
+  margin-top: 0.85rem;
+  border: 1px solid var(--itabs-divider);
+  border-radius: var(--itabs-radius);
+  background: var(--itabs-panel-bg);
+  overflow: hidden;
+  box-shadow: 0 8px 32px -22px rgba(167, 139, 250, 0.4);
+  /* Soft cross-fade on tab change (Vue re-mounts via :key=current.id). */
+  animation: itabs-panel-in 280ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+@keyframes itabs-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .itabs__panel {
+    animation: none;
+  }
+}
+
+.itabs__chrome {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 0.85rem;
+  background: color-mix(in srgb, var(--vp-c-bg) 70%, var(--vp-c-bg-soft));
+  border-bottom: 1px solid var(--itabs-divider);
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.74rem;
+  color: var(--itabs-fg-muted);
+}
+.itabs__dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  opacity: 0.65;
+}
+.itabs__dot--r { background: #ff5f57; }
+.itabs__dot--y { background: #febc2e; }
+.itabs__dot--g { background: #28c840; }
+.itabs__chrome-label {
+  margin-left: 0.5rem;
+  letter-spacing: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.itabs__copy {
+  margin-left: auto;
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--itabs-divider);
+  border-radius: 6px;
+  padding: 0.22rem 0.55rem;
+  font: inherit;
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.72rem;
+  color: var(--itabs-fg-muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  line-height: 1;
+  transition:
+    color 140ms ease,
+    border-color 140ms ease,
+    background 140ms ease;
+  flex-shrink: 0;
+}
+.itabs__copy:hover {
+  color: var(--itabs-fg);
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 50%, var(--itabs-divider));
+  background: color-mix(in srgb, var(--vp-c-brand-1) 5%, transparent);
+}
+.itabs__copy:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--vp-c-brand-1) 55%, transparent);
+}
+.itabs__copy-on {
+  background: linear-gradient(120deg, #f472b6 0%, #a78bfa 50%, #34d399 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.itabs__copy-off {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.32rem;
+}
+
+/* Code block ------------------------------------------------------ */
+
+.itabs__pre {
+  margin: 0;
+  padding: 0.95rem 1rem 1rem;
+  background: var(--itabs-pre-bg);
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.86rem;
+  line-height: 1.6;
+  color: var(--itabs-fg);
+  overflow-x: auto;
+  white-space: pre;
+  /* Tabular nums keeps the $ aligned across lines on long commands. */
+  font-variant-numeric: tabular-nums;
+}
+.itabs__pre code {
+  font: inherit;
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  color: inherit;
+}
+/* VitePress neutralization — its global .vp-doc pre styles would
+   otherwise fight ours. */
+.VPHome .vp-doc .itabs__pre {
+  background: var(--itabs-pre-bg);
+  border: 0;
+  border-radius: 0;
+  padding: 0.95rem 1rem 1rem;
+}
+.VPHome .vp-doc .itabs__pre code {
+  background: transparent;
+  color: inherit;
+}
+
+.itabs__prompt {
+  color: color-mix(in srgb, var(--vp-c-brand-1) 70%, var(--itabs-fg-muted));
+  font-weight: 700;
+  user-select: none;
+  margin-right: 0.55rem;
+}
+.itabs__cmd {
+  color: var(--itabs-fg);
+}
+
+/* Blurb under the panel ------------------------------------------ */
+
+.itabs__blurb {
+  margin: 0;
+  padding: 0.55rem 1rem 0.75rem;
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.76rem;
+  letter-spacing: 0;
+  color: var(--itabs-fg-muted);
+  border-top: 1px solid var(--itabs-divider);
+  background: var(--itabs-panel-bg);
+}
+
+/* Reset VitePress paragraph margins inside our component so the
+   blurb sits flush against the chrome. */
+.VPHome .vp-doc .itabs p,
+.VPHome .vp-doc .itabs .itabs__blurb {
+  margin: 0;
+}
+
+/* Tighten on small screens — chrome label hides, copy button
+   shrinks, tab padding tucks in. */
+@media (max-width: 480px) {
+  .itabs__chrome-label {
+    display: none;
+  }
+  .itabs__tab {
+    padding: 0.4rem 0.55rem 0.5rem;
+    font-size: 0.82rem;
+  }
+  .itabs__pre {
+    font-size: 0.8rem;
+    padding: 0.8rem 0.85rem 0.85rem;
+  }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,10 +17,7 @@ hero:
 
 ## Get started
 
-```sh
-curl -fsSL https://raw.githubusercontent.com/ptmaroct/lfg/main/install.sh | sh
-lfg
-```
+<InstallTabs />
 
 That's it. Pick what you want. `lfg` installs it.
 [Full install guide →](/install)


### PR DESCRIPTION
Closes #41.

## Summary
- Homepage \`Get started\` section now renders three install tabs (brew default → curl → go) instead of a single curl block. Brew first matches the README priority and the actual recommended path now that the tap is live.
- New JSON-LD \`SoftwareApplication\` schema on the homepage so Slack/Discord/search engines understand lfg as a CLI.
- Viewport meta + \`touch-action: manipulation\` CSS to disable pinch zoom across browsers, including iOS Safari (which has ignored \`user-scalable=no\` alone since iOS 10).

## Component design notes
- Terminal-window chrome (3 dots + breadcrumb \`~/ <method>\`) keeps it consistent with the rest of the JetBrains-Mono-heavy site.
- Active tab uses the same pink → violet → emerald gradient as \`.sflow__dot.is-active\` for visual continuity.
- Stagger-in entrance only fires after JS marks the strip primed, so SSR doesn't flash a blank row.
- ARIA \`tablist\` + arrow-key navigation; copy buttons announce \"copied\" via swapped span content.
- Reduced-motion users get instant transitions (no animation, no scale).
- Mobile (≤480px): chrome label hides, tab padding tightens, code font-size drops to 0.8rem.

## Verification
- \`npx vitepress build\` completes clean (38s)
- Built \`dist/index.html\` contains rendered \`itabs__tabs\`, all three labels (brew, curl, go), \`viewport\` meta with \`maximum-scale=1, user-scalable=no\`, and \`@type\":\"SoftwareApplication\"\`
- Manual: please open the preview server (Tailscale URL shared in chat) and click through the tabs, hit the copy button, try arrow keys, and pinch on a phone

## Out of scope (deferred)
- Beta install tab on the homepage — will surface once the first \`lfg-beta\` formula publishes
- Algolia search swap

## Test plan
- [ ] Visual check on the preview URL — tabs work, copy works, gradient underline animates
- [ ] iOS Safari: pinch zoom disabled but inputs still get focus zoom for a11y
- [ ] OG/JSON-LD preview on the twitter card validator after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)