### PR TITLE
ci: bump release-please-action to v5

### DIFF
--- a/.github/workflows/release-please-beta.yml
+++ b/.github/workflows/release-please-beta.yml
@@ -21,7 +21,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config-beta.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json


### PR DESCRIPTION
## Summary
- Bump `googleapis/release-please-action` from v4 → v5 in both workflows.
- Clears the Node.js 20 deprecation warning (v5 ships node24 runtime).
- v5.0.0 only breaking change is the runtime bump; inputs unchanged.

## Test plan
- [ ] Beta release-please workflow passes on next push to develop
- [ ] Stable release-please workflow passes on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)