### PR TITLE
docs: refresh after terminal-essentials bundle + beta release

### DIFF
--- a/docs/guides/bundles.md
+++ b/docs/guides/bundles.md
@@ -14,7 +14,9 @@ The default preset ships with bundles for a typical dev box:
 
 - **barebones** — Homebrew, mise, node-lts, pnpm, bun, yarn, python, uv.
 - **terminal-essentials** — interactive shell quality-of-life: zoxide,
-  ripgrep, lazygit, tailscale, tmux, ghostty, zsh.
+  ripgrep, lazygit, tailscale, tmux, plus `ghostty` (macOS only, brew
+  cask) and `zsh` (Linux only, since recent macOS already ships a
+  current zsh).
 - **ai-harnesses** — AI coding CLIs (Claude Code, Codex, OpenCode, Droid).
 - **skills** — cross-harness AI skills installed via `npx skills add`.
   Gated until `node-lts` is selected.

--- a/docs/guides/update.md
+++ b/docs/guides/update.md
@@ -21,6 +21,20 @@ lfg update --version=v0.3.0
 Useful for downgrading after a regression, or pinning a fleet to a
 known-good release.
 
+## Beta channel
+
+Beta releases ship from `develop` ahead of stable. Two ways to track
+them:
+
+```sh
+brew install ptmaroct/tap/lfg-beta     # parallel install, separate binary
+lfg update --version=v0.4.0-beta.1     # one-off pin, replaces running binary
+```
+
+`lfg update` (no flag) only follows the **latest stable** release —
+beta tags never get auto-pulled. Use the tap formula if you want
+betas to update transparently with `brew upgrade`.
+
 ## How it works
 
 1. Hits `api.github.com/repos/ptmaroct/lfg/releases/latest` (or the

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,7 +3,18 @@ title: Install
 description: Three ways to get the lfg binary on your machine.
 ---
 
-## One-liner (recommended)
+## Homebrew
+
+```sh
+brew install ptmaroct/tap/lfg          # stable
+brew install ptmaroct/tap/lfg-beta     # preview channel — fastest moving
+```
+
+The tap is auto-published by goreleaser on every release. Stable and
+beta install side-by-side as different formulae; pick one or both.
+Upgrade with `brew upgrade ptmaroct/tap/lfg` (or `…/lfg-beta`).
+
+## One-liner
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/ptmaroct/lfg/main/install.sh | sh
@@ -70,8 +81,9 @@ and doesn't drop config until you launch it for the first time.
 Uninstalling is two `rm`s:
 
 ```sh
-rm $(command -v lfg)         # binary
-rm -rf ~/.config/lfg         # state, logs, key, config
+brew uninstall ptmaroct/tap/lfg   # if installed via brew
+rm $(command -v lfg)              # otherwise: remove binary
+rm -rf ~/.config/lfg              # state, logs, key, config
 ```
 
 The `# lfg-managed PATH` block in your shell rc files can be deleted

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -40,10 +40,12 @@ and runs on macOS and Linux (Windows is on the long-term roadmap).
 
 ## Status
 
-v0.3 is shipped: real installers, PostInstall hooks, async live
-version resolver, `lfg backup` / `lfg doctor` / `lfg update`, four
-themes. Snapshot tests still see deterministic mock data so test runs
-never touch your system.
+v0.3 is the latest stable: real installers, PostInstall hooks, async
+live version resolver, `lfg backup` / `lfg doctor` / `lfg update`,
+four themes. v0.4 ships the `terminal-essentials` bundle and renames
+`dev-tools` to `ai-harnesses` — currently on the beta channel via
+`brew install ptmaroct/tap/lfg-beta`. Snapshot tests still see
+deterministic mock data so test runs never touch your system.
 
 The roadmap (sync, SSH fleet management, macOS `defaults` wizard) is
 on the [Roadmap page](/project/roadmap).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,7 +30,8 @@ These work on every command:
 | Flag | Default | Description |
 |---|---|---|
 | `--theme <name>` | `lfg` | Palette: `lfg`, `dracula`, `catppuccin`, `colorblind`. |
-| `--config <path>` | built-in | Custom preset TOML (file path or `http(s)://` URL). |
+| `--config <path>`, `-c` | built-in | Custom preset TOML (file path or `http(s)://` URL). |
+| `--bg <mode>` | `auto` | Force terminal background: `auto`, `dark`, `light`. Also reads `LFG_BG`. |
 | `--debug` | off | Verbose log → `~/.config/lfg/logs/debug-<ts>.log`. |
 | `--dry-run`, `-n` | off | Walk the flow without exec'ing anything. |
 | `--help`, `-h` | — | Show help for the command. |

--- a/docs/reference/preset-schema.md
+++ b/docs/reference/preset-schema.md
@@ -49,6 +49,8 @@ requires = ["node-lts"]   # optional, gate bundle until tool is selected
 | `install_mac` | string | one of | install command on macOS |
 | `install_linux` | string | one of | install command on Linux |
 | `mandatory` | bool | no | always-on, can't be unchecked |
+| `skip_mac` | bool | no | hide this tool on macOS (host filter applied before render) |
+| `skip_linux` | bool | no | hide this tool on Linux (host filter applied before render) |
 | `post_install` | `[]string` | no | shell commands chained after main install |
 | `skill_url` | string | yes if `source=skills` | URL passed to `npx skills add` |
 | `mcp_type` | string | no | `stdio` (default), `http`, or `sse` |
@@ -63,6 +65,13 @@ requires = ["node-lts"]   # optional, gate bundle until tool is selected
 At least one of `install_mac` / `install_linux` is required.
 `post_install` failures surface as warnings — the main install still
 counts as success.
+
+Use `skip_mac` / `skip_linux` when a tool only makes sense on one
+platform. Built-in `terminal-essentials` uses both: `ghostty` ships
+only via macOS cask, and the brew `zsh` override is Linux-only since
+recent macOS already ships a current zsh. Filtered tools never appear
+in the picker, so users on the other OS don't see a placeholder they
+can't act on.
 
 ## Source backends
 

--- a/docs/reference/state.md
+++ b/docs/reference/state.md
@@ -20,8 +20,8 @@ description: What lfg writes under ~/.config/lfg/ and what each file is for.
 ```json
 {
   "theme": "dracula",
-  "version": "v0.3.0",
-  "lastBundles": ["barebones", "ai-harnesses"]
+  "version": "v0.4.0",
+  "lastBundles": ["barebones", "terminal-essentials", "ai-harnesses"]
 }
 ```
 


### PR DESCRIPTION
## Summary

- `install.md` adds Homebrew tap section (`brew install ptmaroct/tap/lfg` stable + `lfg-beta` preview) — was only on landing page, missing from /install
- `preset-schema.md` documents new `skip_mac` / `skip_linux` tool fields
- `bundles.md` notes per-host hides (ghostty mac-only, zsh linux-only)
- `update.md` adds Beta channel section pointing at `lfg-beta` tap formula
- `introduction.md` bumps status — v0.4 ships terminal-essentials + ai-harnesses rename, currently on beta
- `cli.md` documents `--bg` persistent flag + `-c` shorthand for `--config`
- `state.md` cosmetic — example version bumped, lastBundles includes terminal-essentials

No code changes — vitepress build clean locally.

## Test plan

- [ ] commitlint passes (PR title + commit msg)
- [ ] vitepress preview deploy renders without broken links
- [ ] eyeball install.md + update.md for the new brew sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)