### PR TITLE
feat: add shell alias management screen

### DIFF
--- a/internal/cli/apply.go
+++ b/internal/cli/apply.go
@@ -48,7 +48,7 @@ func runApply(cmd *cobra.Command, args []string) error {
 		wanted[a] = true
 	}
 
-	bundles, err := loadPreset()
+	bundles, err := loadBundles()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/default.go
+++ b/internal/cli/default.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/ptmaroct/lfg/internal/installer"
+	"github.com/ptmaroct/lfg/internal/preset"
 	"github.com/ptmaroct/lfg/internal/state"
 	"github.com/ptmaroct/lfg/internal/tui"
 )
@@ -46,7 +47,7 @@ func runTUI() error {
 	// the user sees animated progress instead of a frozen terminal while
 	// goroutines fan out. Probe finishes → transition to welcome with
 	// detect-applied bundles + the harness list set on the installer pkg.
-	bundles, err := loadPreset()
+	loaded, err := loadPreset()
 	if err != nil {
 		return err
 	}
@@ -61,13 +62,29 @@ func runTUI() error {
 		fmt.Fprintln(os.Stderr, "lfg: dry-run mode — no commands will be executed")
 	}
 
+	aliasGroups := preset.GroupAliases(loaded.Aliases)
 	p := tea.NewProgram(
-		tui.NewWithProbe(theme, bundles, opts...),
+		tui.NewWithProbeAndAliases(theme, loaded.Bundles, aliasGroups, opts...),
 		tea.WithAltScreen(),
 	)
 	final, runErr := p.Run()
 	if runErr != nil {
 		return fmt.Errorf("tui run: %w", runErr)
+	}
+
+	// Write user-selected aliases to every detected shell rc. We do
+	// this AFTER the TUI exits so the Charm program owns the terminal
+	// during interactive parts; the actual file write is fast and
+	// non-interactive. Best-effort: errors print to stderr but never
+	// fail the whole run.
+	if m, ok := final.(tui.Model); ok && !dryRun {
+		if picked := m.SelectedAliases(); len(picked) > 0 {
+			if written, werr := installer.EnsureShellAliases(picked); werr != nil {
+				fmt.Fprintln(os.Stderr, "lfg: alias write:", werr)
+			} else if written != "" {
+				fmt.Fprintln(os.Stderr, "lfg: aliases written →", written)
+			}
+		}
 	}
 
 	// On clean exit, save the theme that was active when the user quit

--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 func runExport(cmd *cobra.Command, args []string) error {
-	bundles, err := loadPreset()
+	loaded, err := loadPreset()
 	if err != nil {
 		return err
 	}
@@ -47,11 +47,12 @@ func runExport(cmd *cobra.Command, args []string) error {
 	}
 
 	if dryRun {
-		fmt.Printf("(dry-run) would write %s with %d bundles\n", out, len(bundles))
+		fmt.Printf("(dry-run) would write %s with %d bundles, %d aliases\n",
+			out, len(loaded.Bundles), len(loaded.Aliases))
 		return nil
 	}
 
-	if err := preset.Save(out, bundles); err != nil {
+	if err := preset.Save(out, loaded.Bundles, loaded.Aliases); err != nil {
 		return err
 	}
 	fmt.Printf("✓ saved preset to %s\n", out)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -121,19 +121,39 @@ func applyBg() {
 	lipgloss.SetHasDarkBackground(dark)
 }
 
-// loadPreset returns the bundle slice for this run. Honors --config when
-// set, otherwise falls back to the built-in preset.All(). Errors here
-// are fatal — the user explicitly asked to load a config and we don't
-// want to silently fall back to defaults under their nose.
-func loadPreset() ([]preset.Bundle, error) {
+// loadPreset returns the bundles + aliases for this run. Honors
+// --config when set, otherwise falls back to the built-in
+// preset.All() / preset.DefaultAliasesFlat(). Errors here are fatal —
+// the user explicitly asked to load a config and we don't want to
+// silently fall back to defaults under their nose.
+//
+// REPLACE semantics: when --config provides [[bundles]] those replace
+// the built-ins entirely; same for [[aliases]] (an absent table means
+// "no aliases offered" — opted-out by omission).
+func loadPreset() (preset.Loaded, error) {
 	if configFlag == "" {
-		return preset.FilterForHost(preset.All()), nil
+		return preset.Loaded{
+			Bundles: preset.FilterForHost(preset.All()),
+			Aliases: preset.FilterAliasesForHost(preset.DefaultAliasesFlat()),
+		}, nil
 	}
-	bundles, err := preset.Load(configFlag)
+	loaded, err := preset.Load(configFlag)
 	if err != nil {
-		return nil, fmt.Errorf("load preset %q: %w", configFlag, err)
+		return preset.Loaded{}, fmt.Errorf("load preset %q: %w", configFlag, err)
 	}
-	return preset.FilterForHost(bundles), nil
+	loaded.Bundles = preset.FilterForHost(loaded.Bundles)
+	loaded.Aliases = preset.FilterAliasesForHost(loaded.Aliases)
+	return loaded, nil
+}
+
+// loadBundles is a convenience used by subcommands that don't care
+// about aliases (lfg apply / lfg backup don't touch the alias picker).
+func loadBundles() ([]preset.Bundle, error) {
+	loaded, err := loadPreset()
+	if err != nil {
+		return nil, err
+	}
+	return loaded.Bundles, nil
 }
 
 // resolveTheme picks the theme to use this run. Priority:

--- a/internal/detect/aliases.go
+++ b/internal/detect/aliases.go
@@ -1,0 +1,16 @@
+package detect
+
+import "github.com/ptmaroct/lfg/internal/installer"
+
+// ProbeAliases scans the user's shell rc files for pre-existing alias
+// definitions outside the lfg-managed fenced block. Returned map is
+// keyed by alias name with value `<rc-basename>:<lineno>` so the
+// alias picker can render conflict warnings before the user selects
+// an alias that would clash.
+//
+// Thin wrapper around installer.ExistingAliases — kept here so the
+// probe-phase fan-out in tui/probe.go can import it alongside Probe /
+// ProbeAll without dragging the installer package in directly.
+func ProbeAliases() map[string]string {
+	return installer.ExistingAliases()
+}

--- a/internal/installer/shellaliases.go
+++ b/internal/installer/shellaliases.go
@@ -1,0 +1,199 @@
+package installer
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/ptmaroct/lfg/internal/preset"
+)
+
+// shellAliasMarker fences the lfg-managed alias block in the user's
+// shell rc. Distinct from shellRCMarker so PATH and aliases live in
+// independent fenced regions and can be replaced/removed in isolation.
+const shellAliasMarker = "# lfg-managed aliases (do not edit between markers)"
+const shellAliasEndMarker = "# end lfg-managed aliases"
+
+// EnsureShellAliases writes the user's selected aliases as a fenced
+// block to every detected shell rc (bash, zsh, fish). Idempotent: same
+// inputs produce the same block. Empty input → block is removed
+// (deselecting every alias should leave no orphan markers behind).
+//
+// Returns the comma-joined list of paths actually touched and the
+// first per-file write error (if any) for surface-to-CLI logging.
+func EnsureShellAliases(aliases []preset.Alias) (string, error) {
+	targets := candidateRCs()
+	if len(targets) == 0 {
+		return "", nil
+	}
+	var written []string
+	var firstErr error
+	for _, rc := range targets {
+		existing, _ := os.ReadFile(rc)
+		block := buildAliasBlock(rc, aliases)
+		updated, changed := upsertManagedBlock(string(existing), block, shellAliasMarker, shellAliasEndMarker)
+		if !changed {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(rc), 0o755); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("mkdir %s: %w", filepath.Dir(rc), err)
+			continue
+		}
+		if err := os.WriteFile(rc, []byte(updated), 0o644); err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("write %s: %w", rc, err)
+			}
+			continue
+		}
+		written = append(written, rc)
+	}
+	return strings.Join(written, ", "), firstErr
+}
+
+// buildAliasBlock renders the rc-specific alias snippet. Returns an
+// empty string when there are no aliases to write so upsertManagedBlock
+// strips the prior block in place.
+func buildAliasBlock(rcPath string, aliases []preset.Alias) string {
+	if len(aliases) == 0 {
+		return ""
+	}
+	isFish := strings.HasSuffix(rcPath, "config.fish")
+	var lines []string
+	lines = append(lines, shellAliasMarker)
+	for _, a := range aliases {
+		line := renderAliasLine(rcPath, a, isFish)
+		if line == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	lines = append(lines, shellAliasEndMarker)
+	if len(lines) == 2 {
+		// All aliases skipped → no block.
+		return ""
+	}
+	return strings.Join(lines, "\n")
+}
+
+// renderAliasLine emits one rc line for the given alias.
+//
+// `reload` is special-cased per shell: bash/zsh resolve to a self-exec
+// of the matching shell so PATH/alias edits take effect; fish needs a
+// function (a fish alias of `exec fish` doesn't survive the exec).
+func renderAliasLine(rcPath string, a preset.Alias, isFish bool) string {
+	cmd := a.Command
+	if isFish && a.FishCommand != "" {
+		cmd = a.FishCommand
+	}
+	if a.Name == "reload" {
+		switch {
+		case isFish:
+			return "function reload; exec fish; end"
+		case strings.HasSuffix(rcPath, ".zshrc"):
+			return "alias reload='exec zsh'"
+		default:
+			return "alias reload='exec bash'"
+		}
+	}
+	if cmd == "" || a.Name == "" {
+		return ""
+	}
+	if isFish {
+		return fmt.Sprintf("alias %s %s", a.Name, fishQuote(cmd))
+	}
+	return fmt.Sprintf("alias %s=%s", a.Name, posixSingleQuote(cmd))
+}
+
+// posixSingleQuote wraps s in single quotes for bash/zsh. Embedded
+// single quotes are escaped as '\'' (close-quote, escaped quote,
+// reopen-quote) — the canonical POSIX trick.
+func posixSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// fishQuote wraps s in single quotes for fish. Fish's quoting is
+// simpler than POSIX: backslash-escape internal singles.
+func fishQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `\'`) + "'"
+}
+
+// existingAliasRE matches `alias NAME=...` (bash/zsh) and
+// `alias NAME ...` (fish). Captures the alias name. Optional leading
+// whitespace; ignores commented lines (handled by caller before regex
+// match).
+var existingAliasRE = regexp.MustCompile(`^\s*alias\s+([A-Za-z_][A-Za-z0-9_-]*)\s*[= ]`)
+
+// ExistingAliases scans every candidate rc file for `alias NAME=...`
+// definitions OUTSIDE the lfg-managed fenced block. Returned map is
+// keyed by alias name with value `<rcPath>:<lineNumber>` so the picker
+// can render conflict warnings (`gd ⚠ defined in .zshrc:42`). Lines
+// inside our own fenced block are intentionally skipped: we own those.
+//
+// Best-effort. Read errors are silently swallowed so a missing rc
+// doesn't break the picker — empty map just means "no conflicts found".
+func ExistingAliases() map[string]string {
+	out := map[string]string{}
+	for _, rc := range candidateRCs() {
+		f, err := os.Open(rc)
+		if err != nil {
+			continue
+		}
+		short := shortRCName(rc)
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+		lineNo := 0
+		insideManaged := false
+		for scanner.Scan() {
+			lineNo++
+			line := scanner.Text()
+			trimmed := strings.TrimSpace(line)
+			if strings.Contains(trimmed, shellAliasMarker) {
+				insideManaged = true
+				continue
+			}
+			if strings.Contains(trimmed, shellAliasEndMarker) {
+				insideManaged = false
+				continue
+			}
+			if insideManaged {
+				continue
+			}
+			if strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			m := existingAliasRE.FindStringSubmatch(line)
+			if m == nil {
+				continue
+			}
+			name := m[1]
+			if _, seen := out[name]; seen {
+				continue
+			}
+			out[name] = fmt.Sprintf("%s:%d", short, lineNo)
+		}
+		_ = f.Close()
+	}
+	return out
+}
+
+// shortRCName returns just the basename of an rc path so conflict
+// messages stay terse (`/home/u/.bashrc` → `.bashrc`).
+func shortRCName(p string) string {
+	return filepath.Base(p)
+}
+
+// SortedAliasNames is a tiny helper used by the TUI to render aliases
+// in a stable order across snapshots. Caller-controlled to keep the
+// picker model free of unrelated logic.
+func SortedAliasNames(aliases []preset.Alias) []string {
+	out := make([]string, 0, len(aliases))
+	for _, a := range aliases {
+		out = append(out, a.Name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/installer/shellaliases_test.go
+++ b/internal/installer/shellaliases_test.go
@@ -1,0 +1,138 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ptmaroct/lfg/internal/preset"
+)
+
+func TestBuildAliasBlock_Bash(t *testing.T) {
+	aliases := []preset.Alias{
+		{Name: "gd", Command: "git checkout develop && git pull"},
+		{Name: "reload", Command: "exec $SHELL", FishCommand: "exec fish"},
+	}
+	got := buildAliasBlock("/home/u/.bashrc", aliases)
+	wantLines := []string{
+		shellAliasMarker,
+		`alias gd='git checkout develop && git pull'`,
+		`alias reload='exec bash'`,
+		shellAliasEndMarker,
+	}
+	want := strings.Join(wantLines, "\n")
+	if got != want {
+		t.Errorf("bash block mismatch\n--- want\n%s\n--- got\n%s", want, got)
+	}
+}
+
+func TestBuildAliasBlock_Zsh(t *testing.T) {
+	aliases := []preset.Alias{
+		{Name: "reload", Command: "exec $SHELL"},
+	}
+	got := buildAliasBlock("/home/u/.zshrc", aliases)
+	if !strings.Contains(got, "alias reload='exec zsh'") {
+		t.Errorf("expected zsh reload line, got:\n%s", got)
+	}
+}
+
+func TestBuildAliasBlock_Fish(t *testing.T) {
+	aliases := []preset.Alias{
+		{Name: "gd", Command: "git diff"},
+		{Name: "reload", Command: "exec $SHELL", FishCommand: "exec fish"},
+	}
+	got := buildAliasBlock("/home/u/.config/fish/config.fish", aliases)
+	if !strings.Contains(got, "alias gd 'git diff'") {
+		t.Errorf("expected fish-style alias line, got:\n%s", got)
+	}
+	if !strings.Contains(got, "function reload; exec fish; end") {
+		t.Errorf("expected fish reload function, got:\n%s", got)
+	}
+}
+
+func TestBuildAliasBlock_Empty(t *testing.T) {
+	if got := buildAliasBlock("/home/u/.bashrc", nil); got != "" {
+		t.Errorf("empty alias list should produce empty block, got: %q", got)
+	}
+}
+
+func TestPosixSingleQuote_EscapesQuote(t *testing.T) {
+	got := posixSingleQuote(`echo 'hi'`)
+	want := `'echo '\''hi'\'''`
+	if got != want {
+		t.Errorf("posix quote escape: want %q, got %q", want, got)
+	}
+}
+
+func TestEnsureShellAliases_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	rc := filepath.Join(dir, ".bashrc")
+	if err := os.WriteFile(rc, []byte("# pre-existing rc\nalias old='echo old'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SHELL", "/bin/bash")
+
+	aliases := []preset.Alias{
+		{Name: "gd", Command: "git status"},
+	}
+	if _, err := EnsureShellAliases(aliases); err != nil {
+		t.Fatalf("EnsureShellAliases: %v", err)
+	}
+	data, err := os.ReadFile(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+	if !strings.Contains(body, shellAliasMarker) {
+		t.Errorf("rc missing alias start marker:\n%s", body)
+	}
+	if !strings.Contains(body, "alias gd='git status'") {
+		t.Errorf("rc missing alias line:\n%s", body)
+	}
+	if !strings.Contains(body, "alias old='echo old'") {
+		t.Errorf("rc lost pre-existing alias:\n%s", body)
+	}
+
+	// Second pass with empty list should remove the block.
+	if _, err := EnsureShellAliases(nil); err != nil {
+		t.Fatalf("EnsureShellAliases empty: %v", err)
+	}
+	data, _ = os.ReadFile(rc)
+	body = string(data)
+	if strings.Contains(body, shellAliasMarker) {
+		t.Errorf("empty input should strip block, still present:\n%s", body)
+	}
+	if !strings.Contains(body, "alias old='echo old'") {
+		t.Errorf("pre-existing alias lost on empty pass:\n%s", body)
+	}
+}
+
+func TestExistingAliases_SkipsManagedBlock(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	rc := filepath.Join(dir, ".bashrc")
+	body := strings.Join([]string{
+		"alias user_owned='echo'",
+		shellAliasMarker,
+		"alias managed='inside lfg block'",
+		shellAliasEndMarker,
+		"alias post='after'",
+	}, "\n")
+	if err := os.WriteFile(rc, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SHELL", "/bin/bash")
+
+	got := ExistingAliases()
+	if _, ok := got["managed"]; ok {
+		t.Errorf("ExistingAliases must not surface aliases inside lfg block: %+v", got)
+	}
+	if _, ok := got["user_owned"]; !ok {
+		t.Errorf("ExistingAliases must surface user-owned aliases: %+v", got)
+	}
+	if _, ok := got["post"]; !ok {
+		t.Errorf("ExistingAliases must surface aliases after the block: %+v", got)
+	}
+}

--- a/internal/installer/shellrc.go
+++ b/internal/installer/shellrc.go
@@ -34,7 +34,7 @@ func EnsureShellPath() (string, error) {
 	var firstErr error
 	for _, rc := range targets {
 		existing, _ := os.ReadFile(rc)
-		updated, changed := upsertManagedBlock(string(existing), block)
+		updated, changed := upsertManagedBlock(string(existing), block, shellRCMarker, shellRCEndMarker)
 		if !changed {
 			continue
 		}
@@ -164,12 +164,18 @@ func buildShellBlock() string {
 }
 
 // upsertManagedBlock replaces an existing fenced block in `existing`
-// with `block`, or appends one if absent. Returns the new file content
-// and a bool indicating whether anything changed.
-func upsertManagedBlock(existing, block string) (string, bool) {
-	startIdx := strings.Index(existing, shellRCMarker)
-	endIdx := strings.Index(existing, shellRCEndMarker)
+// with `block`, or appends one if absent. The fence is identified by
+// the marker pair so the same logic powers both the PATH block
+// (shellRC.go) and the alias block (shellaliases.go). Returns the new
+// file content and a bool indicating whether anything changed.
+func upsertManagedBlock(existing, block, startMarker, endMarker string) (string, bool) {
+	startIdx := strings.Index(existing, startMarker)
+	endIdx := strings.Index(existing, endMarker)
 	if startIdx == -1 || endIdx == -1 || endIdx < startIdx {
+		// Block is being removed and didn't exist → no-op.
+		if strings.TrimSpace(block) == "" {
+			return existing, false
+		}
 		// Append. Ensure single newline between old content + block.
 		out := strings.TrimRight(existing, "\n")
 		if out != "" {
@@ -178,8 +184,26 @@ func upsertManagedBlock(existing, block string) (string, bool) {
 		out += block + "\n"
 		return out, true
 	}
-	// Replace in-place.
-	endIdx += len(shellRCEndMarker)
+	// Replace in-place. If the new block is empty, strip the entire
+	// fenced section so deselecting all aliases leaves no orphan markers.
+	endIdx += len(endMarker)
+	if strings.TrimSpace(block) == "" {
+		// Trim a trailing newline left over from the prior block so the
+		// file doesn't accumulate blank lines on repeated empty writes.
+		tail := existing[endIdx:]
+		if strings.HasPrefix(tail, "\n") {
+			tail = tail[1:]
+		}
+		head := strings.TrimRight(existing[:startIdx], "\n")
+		if head != "" && tail != "" {
+			head += "\n"
+		}
+		rebuilt := head + tail
+		if rebuilt == existing {
+			return existing, false
+		}
+		return rebuilt, true
+	}
 	rebuilt := existing[:startIdx] + block + existing[endIdx:]
 	if rebuilt == existing {
 		return existing, false

--- a/internal/preset/alias.go
+++ b/internal/preset/alias.go
@@ -1,0 +1,117 @@
+package preset
+
+import "runtime"
+
+// Alias is a single shell alias the user can opt into during setup.
+// Written into a fenced lfg-managed block in every detected shell rc
+// by installer.EnsureShellAliases. Top-level (not nested in Bundle)
+// because alias selection is orthogonal to the install plan: a user
+// without claude installed can still want `c` / `cr` configured for
+// later, and aliases survive a `chsh`.
+type Alias struct {
+	Name        string `toml:"name"`
+	Command     string `toml:"command"`
+	FishCommand string `toml:"fish_command,omitempty"`
+	Description string `toml:"description,omitempty"`
+	Group       string `toml:"group,omitempty"`
+	Default     bool   `toml:"default,omitempty"`
+	SkipMac     bool   `toml:"skip_mac,omitempty"`
+	SkipLinux   bool   `toml:"skip_linux,omitempty"`
+}
+
+// AliasGroup buckets aliases by intent for the picker UI.
+type AliasGroup struct {
+	ID          string
+	Name        string
+	Description string
+	Aliases     []Alias
+}
+
+const (
+	AliasGroupGit    = "git"
+	AliasGroupClaude = "claude"
+	AliasGroupShell  = "shell"
+)
+
+// DefaultAliasesFlat is the hardcoded default catalog (used when no
+// `--config` provides its own [[aliases]] table).
+func DefaultAliasesFlat() []Alias {
+	return []Alias{
+		{Name: "gd", Command: "git checkout develop && git pull", Description: "checkout develop + pull", Group: AliasGroupGit, Default: true},
+		{Name: "gf", Command: "git fetch --all --prune", Description: "fetch all remotes, prune", Group: AliasGroupGit, Default: true},
+		{Name: "gs", Command: "git status", Description: "git status", Group: AliasGroupGit, Default: true},
+		{Name: "gp", Command: "git push", Description: "git push", Group: AliasGroupGit, Default: true},
+		{Name: "gl", Command: "git log --oneline -20", Description: "compact recent log", Group: AliasGroupGit, Default: true},
+		{Name: "gco", Command: "git checkout", Description: "git checkout", Group: AliasGroupGit, Default: true},
+
+		{Name: "c", Command: "claude", Description: "claude (normal mode)", Group: AliasGroupClaude, Default: true},
+		{Name: "cr", Command: "claude --resume", Description: "claude resume", Group: AliasGroupClaude, Default: true},
+		{Name: "cw", Command: "claude worktree", Description: "claude worktree", Group: AliasGroupClaude, Default: true},
+
+		// reload is per-shell special-cased by buildAliasBlock — bash/zsh
+		// emit `alias reload='exec bash|zsh'`, fish emits a function.
+		{Name: "reload", Command: "exec $SHELL", FishCommand: "exec fish", Description: "reload current shell", Group: AliasGroupShell, Default: true},
+	}
+}
+
+// DefaultAliases returns the default catalog grouped for picker UI.
+func DefaultAliases() []AliasGroup {
+	return GroupAliases(DefaultAliasesFlat())
+}
+
+// GroupAliases buckets a flat slice into ordered AliasGroups.
+// Groups appear in the canonical order: git, claude, shell, then any
+// custom Group values in first-seen order. Aliases keep their input
+// order within each group.
+func GroupAliases(flat []Alias) []AliasGroup {
+	if len(flat) == 0 {
+		return nil
+	}
+	meta := map[string]struct{ name, desc string }{
+		AliasGroupGit:    {"git", "git workflow shortcuts"},
+		AliasGroupClaude: {"claude", "claude code shortcuts"},
+		AliasGroupShell:  {"shell", "shell helpers"},
+	}
+	order := []string{AliasGroupGit, AliasGroupClaude, AliasGroupShell}
+	seen := map[string]bool{AliasGroupGit: true, AliasGroupClaude: true, AliasGroupShell: true}
+	bucket := map[string][]Alias{}
+	for _, a := range flat {
+		g := a.Group
+		if g == "" {
+			g = "custom"
+		}
+		if !seen[g] {
+			seen[g] = true
+			order = append(order, g)
+		}
+		bucket[g] = append(bucket[g], a)
+	}
+	out := make([]AliasGroup, 0, len(order))
+	for _, id := range order {
+		if len(bucket[id]) == 0 {
+			continue
+		}
+		m, ok := meta[id]
+		if !ok {
+			m = struct{ name, desc string }{id, ""}
+		}
+		out = append(out, AliasGroup{ID: id, Name: m.name, Description: m.desc, Aliases: bucket[id]})
+	}
+	return out
+}
+
+// FilterAliasesForHost drops aliases whose Skip{Mac,Linux} matches
+// the running OS. Mirror of FilterForHost (preset.go:12).
+func FilterAliasesForHost(in []Alias) []Alias {
+	out := make([]Alias, 0, len(in))
+	for _, a := range in {
+		if runtime.GOOS == "darwin" && a.SkipMac {
+			continue
+		}
+		if runtime.GOOS != "darwin" && a.SkipLinux {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}

--- a/internal/preset/loader.go
+++ b/internal/preset/loader.go
@@ -12,18 +12,27 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-// presetFile is the on-disk schema. Top-level "bundles" array of Bundle.
+// presetFile is the on-disk schema. Top-level "bundles" array of Bundle
+// plus an optional top-level "aliases" array of Alias for shell aliases.
 type presetFile struct {
 	Bundles []Bundle `toml:"bundles"`
+	Aliases []Alias  `toml:"aliases,omitempty"`
+}
+
+// Loaded is the parsed config. Bundles is required, Aliases is optional
+// (empty when the config omits [[aliases]] — opted-out by omission).
+type Loaded struct {
+	Bundles []Bundle
+	Aliases []Alias
 }
 
 // Load resolves a config spec (local path or http(s) URL) and returns
-// the parsed bundles. Empty spec is treated as an error — callers
-// should branch on the empty case before calling.
-func Load(spec string) ([]Bundle, error) {
+// the parsed bundles + aliases. Empty spec is treated as an error —
+// callers should branch on the empty case before calling.
+func Load(spec string) (Loaded, error) {
 	spec = strings.TrimSpace(spec)
 	if spec == "" {
-		return nil, fmt.Errorf("empty preset spec")
+		return Loaded{}, fmt.Errorf("empty preset spec")
 	}
 	if strings.HasPrefix(spec, "http://") || strings.HasPrefix(spec, "https://") {
 		return LoadFromURL(spec)
@@ -31,47 +40,46 @@ func Load(spec string) ([]Bundle, error) {
 	return LoadFromPath(spec)
 }
 
-// LoadFromPath reads a TOML file from disk and parses it into bundles.
-func LoadFromPath(path string) ([]Bundle, error) {
+// LoadFromPath reads a TOML file from disk.
+func LoadFromPath(path string) (Loaded, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read %s: %w", path, err)
+		return Loaded{}, fmt.Errorf("read %s: %w", path, err)
 	}
 	return parse(data, path)
 }
 
 // LoadFromURL fetches a TOML file over HTTP(S) (10s hard timeout) and
-// parses it. Caps the body at 1 MiB to keep a hostile URL from
-// exhausting memory.
-func LoadFromURL(url string) ([]Bundle, error) {
+// parses it. Caps the body at 1 MiB.
+func LoadFromURL(url string) (Loaded, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
+		return Loaded{}, fmt.Errorf("build request: %w", err)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fetch %s: %w", url, err)
+		return Loaded{}, fmt.Errorf("fetch %s: %w", url, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fetch %s: status %d", url, resp.StatusCode)
+		return Loaded{}, fmt.Errorf("fetch %s: status %d", url, resp.StatusCode)
 	}
 	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return nil, fmt.Errorf("read body: %w", err)
+		return Loaded{}, fmt.Errorf("read body: %w", err)
 	}
 	return parse(data, url)
 }
 
-func parse(data []byte, source string) ([]Bundle, error) {
+func parse(data []byte, source string) (Loaded, error) {
 	var pf presetFile
 	if err := toml.Unmarshal(data, &pf); err != nil {
-		return nil, fmt.Errorf("parse %s: %w", source, err)
+		return Loaded{}, fmt.Errorf("parse %s: %w", source, err)
 	}
 	if len(pf.Bundles) == 0 {
-		return nil, fmt.Errorf("parse %s: no [[bundles]] entries found", source)
+		return Loaded{}, fmt.Errorf("parse %s: no [[bundles]] entries found", source)
 	}
-	return pf.Bundles, nil
+	return Loaded{Bundles: pf.Bundles, Aliases: pf.Aliases}, nil
 }

--- a/internal/preset/loader_test.go
+++ b/internal/preset/loader_test.go
@@ -19,21 +19,32 @@ default = true
   source = "brew"
 `
 
+const sampleWithAliases = sample + `
+[[aliases]]
+name = "ll"
+command = "ls -la"
+group = "shell"
+default = true
+`
+
 func TestLoadFromPath(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "preset.toml")
 	if err := os.WriteFile(path, []byte(sample), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	bundles, err := Load(path)
+	loaded, err := Load(path)
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if len(bundles) != 1 || bundles[0].ID != "minimal" {
-		t.Fatalf("bad bundles: %+v", bundles)
+	if len(loaded.Bundles) != 1 || loaded.Bundles[0].ID != "minimal" {
+		t.Fatalf("bad bundles: %+v", loaded.Bundles)
 	}
-	if len(bundles[0].Tools) != 1 || bundles[0].Tools[0].Name != "git" {
-		t.Fatalf("bad tools: %+v", bundles[0].Tools)
+	if len(loaded.Bundles[0].Tools) != 1 || loaded.Bundles[0].Tools[0].Name != "git" {
+		t.Fatalf("bad tools: %+v", loaded.Bundles[0].Tools)
+	}
+	if len(loaded.Aliases) != 0 {
+		t.Fatalf("expected no aliases, got %+v", loaded.Aliases)
 	}
 }
 
@@ -43,12 +54,12 @@ func TestLoadFromURL(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	bundles, err := Load(srv.URL)
+	loaded, err := Load(srv.URL)
 	if err != nil {
 		t.Fatalf("Load url: %v", err)
 	}
-	if len(bundles) != 1 || bundles[0].ID != "minimal" {
-		t.Fatalf("bad bundles: %+v", bundles)
+	if len(loaded.Bundles) != 1 || loaded.Bundles[0].ID != "minimal" {
+		t.Fatalf("bad bundles: %+v", loaded.Bundles)
 	}
 }
 
@@ -83,5 +94,23 @@ func TestLoadEmptyBundles(t *testing.T) {
 	}
 	if _, err := Load(path); err == nil {
 		t.Fatal("expected error on no [[bundles]]")
+	}
+}
+
+func TestLoadWithAliases(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "aliases.toml")
+	if err := os.WriteFile(path, []byte(sampleWithAliases), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Aliases) != 1 || loaded.Aliases[0].Name != "ll" {
+		t.Fatalf("bad aliases: %+v", loaded.Aliases)
+	}
+	if loaded.Aliases[0].Command != "ls -la" {
+		t.Fatalf("bad alias command: %q", loaded.Aliases[0].Command)
 	}
 }

--- a/internal/preset/save.go
+++ b/internal/preset/save.go
@@ -8,15 +8,15 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-// Save writes the bundles back to a TOML file matching the loader's
-// schema. Used by `lfg export` and the in-TUI "save preset" flow so
-// users can capture their machine's tool set as a portable file and
-// re-load it elsewhere with `lfg --config <file>`.
-func Save(path string, bundles []Bundle) error {
+// Save writes bundles + aliases back to a TOML file matching the
+// loader's schema. Used by `lfg export` and the in-TUI "save preset"
+// flow so users can capture their machine's tool set as a portable
+// file and re-load it elsewhere with `lfg --config <file>`.
+func Save(path string, bundles []Bundle, aliases []Alias) error {
 	if path == "" {
 		return fmt.Errorf("empty output path")
 	}
-	pf := presetFile{Bundles: bundles}
+	pf := presetFile{Bundles: bundles, Aliases: aliases}
 	var buf bytes.Buffer
 	enc := toml.NewEncoder(&buf)
 	enc.Indent = "  "

--- a/internal/tui/aliases.go
+++ b/internal/tui/aliases.go
@@ -1,0 +1,231 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/huh"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/ptmaroct/lfg/internal/preset"
+)
+
+// aliasesModel — shell-alias picker rendered after install (between
+// progress and done). Lowest priority in the setup flow: aliases are
+// quality-of-life, never blocking. Skipped entirely when there are no
+// aliases to offer (empty config or DefaultAliases returned nothing).
+//
+// Single huh.MultiSelect with options grouped visually by sorting on
+// AliasGroup; conflicts (alias name already defined in a user rc) get
+// rendered as a `⚠` suffix on the option label so the user sees the
+// risk before they hit submit.
+type aliasesModel struct {
+	palette   Palette
+	form      *huh.Form
+	groups    []preset.AliasGroup
+	flat      []preset.Alias
+	conflicts map[string]string
+	keys      []string // option key per visible alias, indexed parallel to flat
+	selected  []string // bound by huh.MultiSelect
+	skipped   bool
+}
+
+// flattenGroups returns the aliases in canonical group order so the
+// picker renders gits together, claudes together, shell helpers last.
+func flattenGroups(groups []preset.AliasGroup) []preset.Alias {
+	var out []preset.Alias
+	for _, g := range groups {
+		out = append(out, g.Aliases...)
+	}
+	return out
+}
+
+func newAliases(p Palette, groups []preset.AliasGroup, preselected map[string]bool, conflicts map[string]string) aliasesModel {
+	flat := flattenGroups(groups)
+	m := aliasesModel{
+		palette:   p,
+		groups:    groups,
+		flat:      flat,
+		conflicts: conflicts,
+		keys:      make([]string, 0, len(flat)),
+	}
+	if len(flat) == 0 {
+		m.skipped = true
+		return m
+	}
+
+	opts := make([]huh.Option[string], 0, len(flat))
+	for _, a := range flat {
+		key := a.Group + "/" + a.Name
+		m.keys = append(m.keys, key)
+		opts = append(opts, huh.NewOption(aliasOptionLabel(a, conflicts), key).
+			Selected(aliasIsSelected(a, key, preselected)))
+	}
+
+	m.form = huh.NewForm(
+		huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title("Pick shell aliases").
+				Description("Selected aliases get added to a fenced lfg-managed block in your shell rc(s).\nYou can re-run lfg anytime to change selection.").
+				Options(opts...).
+				Value(&m.selected).
+				Height(min(14, len(opts)+2)),
+		),
+	).
+		WithTheme(HuhTheme(p)).
+		WithShowHelp(false).
+		WithShowErrors(false)
+	return m
+}
+
+// aliasIsSelected returns true if either the user's prior selection
+// includes the key or the alias is a default and there's no prior
+// selection map (empty map = first visit, honor defaults).
+func aliasIsSelected(a preset.Alias, key string, pre map[string]bool) bool {
+	if len(pre) > 0 {
+		return pre[key]
+	}
+	return a.Default
+}
+
+// aliasOptionLabel formats one option line for the picker.
+//
+// Layout: `<NAME>  <description> · <command>`. When a conflict is
+// detected (name already defined in a user rc outside the lfg block)
+// we suffix `⚠ in <rc>:<line>` so the user knows what they'd shadow.
+func aliasOptionLabel(a preset.Alias, conflicts map[string]string) string {
+	desc := a.Description
+	if desc == "" {
+		desc = a.Command
+	}
+	label := fmt.Sprintf("%-7s %s", a.Name, desc)
+	if conflicts != nil {
+		if where, ok := conflicts[a.Name]; ok {
+			label += fmt.Sprintf("  ⚠ in %s", where)
+		}
+	}
+	return label
+}
+
+func (m aliasesModel) Init() tea.Cmd {
+	if m.skipped || m.form == nil {
+		return nil
+	}
+	return m.form.Init()
+}
+
+func (m aliasesModel) Update(msg tea.Msg) (aliasesModel, tea.Cmd) {
+	if m.skipped {
+		if k, ok := msg.(tea.KeyMsg); ok {
+			switch k.String() {
+			case "enter", "esc", " ":
+				return m, goTo(screenDone)
+			}
+		}
+		return m, nil
+	}
+	if k, ok := msg.(tea.KeyMsg); ok {
+		switch k.String() {
+		case "esc":
+			// Skip — proceed without writing aliases.
+			return m, m.advance(nil)
+		case "ctrl+s":
+			// Power-user shortcut: submit current selection.
+			return m, m.advance(m.selectedSet())
+		}
+	}
+	f, cmd := m.form.Update(msg)
+	if ff, ok := f.(*huh.Form); ok {
+		m.form = ff
+	}
+	if m.form.State == huh.StateCompleted {
+		return m, m.advance(m.selectedSet())
+	}
+	return m, cmd
+}
+
+// selectedSet converts huh's []string slice into the keyed map the
+// root model carries.
+func (m aliasesModel) selectedSet() map[string]bool {
+	out := map[string]bool{}
+	for _, k := range m.selected {
+		out[k] = true
+	}
+	return out
+}
+
+// advance returns a cmd that hops to screenDone with the alias
+// selection threaded through. nil → user skipped, no aliases written.
+func (m aliasesModel) advance(set map[string]bool) tea.Cmd {
+	return func() tea.Msg {
+		return transitionMsg{
+			target:          screenDone,
+			selectedAliases: set,
+		}
+	}
+}
+
+func (m aliasesModel) View(width, height int) string {
+	p := m.palette
+	canvasW := CanvasW(width)
+	contentW := canvasW - 4
+
+	var b strings.Builder
+	b.WriteString(SectionLabel(p, "Shell aliases", "optional · written to your rc", contentW))
+	b.WriteString("\n\n")
+
+	if m.skipped {
+		b.WriteString("  " + lipgloss.NewStyle().Foreground(p.Muted).Italic(true).
+			Render("no aliases offered — proceeding") + "\n")
+		return Frame(p, width, height,
+			"step 4 · aliases",
+			b.String(),
+			HintLine(p, KeyHint(p, "⏎", "continue")),
+			height < 22,
+		)
+	}
+
+	intro := lipgloss.NewStyle().Foreground(p.Muted).
+		Render("  Quality-of-life shortcuts. We write a fenced block to every detected\n  shell rc; deselecting all leaves your rc unchanged.")
+	b.WriteString(intro + "\n\n")
+
+	if len(m.conflicts) > 0 {
+		warn := lipgloss.NewStyle().Foreground(p.Warn).Bold(true).Render("  ⚠ ")
+		warnText := lipgloss.NewStyle().Foreground(p.Muted).Render(
+			"some names already defined in your rc — selecting will shadow the existing alias")
+		b.WriteString(warn + warnText + "\n\n")
+	}
+
+	b.WriteString(m.form.View())
+
+	return Frame(p, width, height,
+		"step 4 · aliases",
+		b.String(),
+		HintLine(p,
+			KeyHint(p, "x", "toggle"),
+			KeyHint(p, "⏎", "continue"),
+			KeyHint(p, "^S", "submit now"),
+			KeyHint(p, "ESC", "skip"),
+		),
+		height < 22,
+	)
+}
+
+// resolveSelectedAliases walks the alias catalog and returns the
+// concrete []preset.Alias the user picked. Order preserved per the
+// catalog's group ordering (so the rc block is stable across runs).
+func resolveSelectedAliases(groups []preset.AliasGroup, selected map[string]bool) []preset.Alias {
+	if len(selected) == 0 {
+		return nil
+	}
+	var out []preset.Alias
+	for _, g := range groups {
+		for _, a := range g.Aliases {
+			if selected[a.Group+"/"+a.Name] {
+				out = append(out, a)
+			}
+		}
+	}
+	return out
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -18,6 +18,7 @@ const (
 	screenConfirm
 	screenCreds // MCP credentials wizard, between confirm and progress
 	screenProgress
+	screenAliases // optional shell aliases — between progress and done
 	screenDone
 	screenBackupPrompt
 	screenBackupDone
@@ -47,6 +48,7 @@ type Model struct {
 	confirm      confirmModel
 	creds        credsModel
 	progress     progressModel
+	aliases      aliasesModel
 	done         doneModel
 	backup       backupModel
 	quitConfirm  quitConfirmModel
@@ -58,6 +60,14 @@ type Model struct {
 
 	selectedBundleIDs map[string]bool
 	selectedTools     map[string]bool // key = bundleID + "/" + toolName
+
+	// Alias state. aliasGroups is the catalog (defaults or config-driven);
+	// selectedAliases keys are <group>/<aliasName>; aliasConflicts maps
+	// alias name → "<rc-basename>:<line>" for pre-existing definitions
+	// outside the lfg-managed block (populated during the probe phase).
+	aliasGroups     []preset.AliasGroup
+	selectedAliases map[string]bool
+	aliasConflicts  map[string]string
 
 	// progressRunner is injected via WithProgressRunner; nil → mock.
 	progressRunner ProgressRunner
@@ -86,8 +96,19 @@ func New(theme ThemeName) Model {
 
 // NewWithBundles is the explicit constructor used after a detect pass.
 // Pass the bundle slice with Installed/Version fields already overlaid
-// (see internal/detect.Apply).
+// (see internal/detect.Apply). Defaults aliases to the built-in
+// catalog with no conflict map; callers wanting config-driven aliases
+// or pre-probed conflicts should use NewWithBundlesAndAliases.
 func NewWithBundles(theme ThemeName, bundles []preset.Bundle, opts ...Option) Model {
+	return NewWithBundlesAndAliases(theme, bundles, preset.DefaultAliases(), nil, opts...)
+}
+
+// NewWithBundlesAndAliases is the full constructor — bundles + alias
+// catalog + alias conflict map (probed from rc files). Callers driven
+// by --config thread their parsed catalog through here so the alias
+// picker honors the config as source of truth (REPLACE semantics, same
+// as bundle precedence).
+func NewWithBundlesAndAliases(theme ThemeName, bundles []preset.Bundle, aliasGroups []preset.AliasGroup, conflicts map[string]string, opts ...Option) Model {
 	p := PaletteFor(theme)
 	pre := map[string]bool{}
 	for _, bundle := range bundles {
@@ -102,6 +123,8 @@ func NewWithBundles(theme ThemeName, bundles []preset.Bundle, opts ...Option) Mo
 		bundles:           bundles,
 		selectedBundleIDs: pre,
 		selectedTools:     map[string]bool{},
+		aliasGroups:       aliasGroups,
+		aliasConflicts:    conflicts,
 	}
 	m.welcome = newWelcome(p)
 	for _, o := range opts {
@@ -115,8 +138,16 @@ func NewWithBundles(theme ThemeName, bundles []preset.Bundle, opts ...Option) Mo
 // instead of a frozen terminal. The probe screen runs detect.ProbeAll
 // in the background, then transitions to welcome with the result-applied
 // bundles. Snapshot tests intentionally use New / NewWithBundles so they
-// skip the probe step (deterministic state).
+// skip the probe step (deterministic state). Alias catalog defaults to
+// the built-in set; use NewWithProbeAndAliases for config-driven catalog.
 func NewWithProbe(theme ThemeName, raw []preset.Bundle, opts ...Option) Model {
+	return NewWithProbeAndAliases(theme, raw, preset.DefaultAliases(), opts...)
+}
+
+// NewWithProbeAndAliases lets callers thread a custom alias catalog
+// through the probe-first startup path. Alias conflicts get probed
+// alongside detect and arrive via probeAliasesMsg.
+func NewWithProbeAndAliases(theme ThemeName, raw []preset.Bundle, aliasGroups []preset.AliasGroup, opts ...Option) Model {
 	p := PaletteFor(theme)
 	pre := map[string]bool{}
 	for _, bundle := range raw {
@@ -131,6 +162,7 @@ func NewWithProbe(theme ThemeName, raw []preset.Bundle, opts ...Option) Model {
 		bundles:           raw,
 		selectedBundleIDs: pre,
 		selectedTools:     map[string]bool{},
+		aliasGroups:       aliasGroups,
 	}
 	m.probe = newProbe(p, raw)
 	for _, o := range opts {
@@ -149,6 +181,13 @@ func (m Model) Init() tea.Cmd {
 // Theme returns the currently active theme name. Used by the CLI layer
 // to persist theme changes (Ctrl+T cycling) on clean exit.
 func (m Model) Theme() ThemeName { return m.theme }
+
+// SelectedAliases returns the resolved alias slice the user picked,
+// in catalog order. Used by the CLI layer to write the lfg-managed
+// alias block to shell rc files after the TUI exits.
+func (m Model) SelectedAliases() []preset.Alias {
+	return resolveSelectedAliases(m.aliasGroups, m.selectedAliases)
+}
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
@@ -217,6 +256,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.creds, cmd = m.creds.Update(msg)
 	case screenProgress:
 		m.progress, cmd = m.progress.Update(msg)
+	case screenAliases:
+		m.aliases, cmd = m.aliases.Update(msg)
 	case screenDone:
 		m.done, cmd = m.done.Update(msg)
 	case screenBackupPrompt, screenBackupDone:
@@ -252,6 +293,8 @@ func (m Model) forwardSize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 		m.creds, cmd = m.creds.Update(msg)
 	case screenProgress:
 		m.progress, cmd = m.progress.Update(msg)
+	case screenAliases:
+		m.aliases, cmd = m.aliases.Update(msg)
 	case screenDone:
 		m.done, cmd = m.done.Update(msg)
 	case screenBackupPrompt, screenBackupDone:
@@ -286,6 +329,8 @@ func (m Model) View() string {
 		return m.creds.View(m.width, m.height)
 	case screenProgress:
 		return m.progress.View(m.width, m.height)
+	case screenAliases:
+		return m.aliases.View(m.width, m.height)
 	case screenDone:
 		return m.done.View(m.width, m.height)
 	case screenBackupPrompt, screenBackupDone:
@@ -319,12 +364,19 @@ func openInfoCmd(bundleID string, t preset.Tool) tea.Cmd {
 
 // transitionMsg requests a screen change, optionally carrying state.
 // `bundles` lets the probe screen replace the root bundle slice with
-// detect-applied data when handing off to welcome.
+// detect-applied data when handing off to welcome. `selectedAliases`
+// flows out of the alias picker; `aliasConflicts` flows in from the
+// probe phase. `aliasGroups` lets a runtime --config load (from the
+// welcome screen) swap the alias catalog mid-session.
 type transitionMsg struct {
 	target            screen
 	selectedBundleIDs map[string]bool
 	selectedTools     map[string]bool
+	selectedAliases   map[string]bool
 	bundles           []preset.Bundle
+	aliasGroups       []preset.AliasGroup
+	aliasConflicts    map[string]string
+	replaceAliases    bool // when true, aliasGroups replaces (even if empty)
 }
 
 func (m Model) transition(msg transitionMsg) (tea.Model, tea.Cmd) {
@@ -333,6 +385,18 @@ func (m Model) transition(msg transitionMsg) (tea.Model, tea.Cmd) {
 	}
 	if msg.selectedTools != nil {
 		m.selectedTools = msg.selectedTools
+	}
+	if msg.selectedAliases != nil {
+		m.selectedAliases = msg.selectedAliases
+	}
+	if msg.aliasConflicts != nil {
+		m.aliasConflicts = msg.aliasConflicts
+	}
+	if msg.replaceAliases {
+		m.aliasGroups = msg.aliasGroups
+		// Reset prior selection when the catalog changes — the keys
+		// (group/name) likely don't carry over to the new catalog.
+		m.selectedAliases = nil
 	}
 	if msg.bundles != nil {
 		m.bundles = msg.bundles
@@ -376,8 +440,11 @@ func (m Model) transition(msg transitionMsg) (tea.Model, tea.Cmd) {
 		}
 		m.progress = newProgressWithRunner(m.palette, m.bundles, m.selectedTools, runner)
 		return m, m.progress.Init()
+	case screenAliases:
+		m.aliases = newAliases(m.palette, m.aliasGroups, m.selectedAliases, m.aliasConflicts)
+		return m, m.aliases.Init()
 	case screenDone:
-		m.done = newDone(m.palette, m.bundles, m.selectedTools)
+		m.done = newDone(m.palette, m.bundles, m.selectedTools, resolveSelectedAliases(m.aliasGroups, m.selectedAliases))
 		return m, m.done.Init()
 	case screenBackupPrompt:
 		m.backup = newBackup(m.palette)
@@ -395,7 +462,7 @@ func (m Model) transition(msg transitionMsg) (tea.Model, tea.Cmd) {
 		// Restored after info dialog closes; the model already exists.
 		return m, nil
 	case screenExport:
-		m.export = newExport(m.palette, m.bundles)
+		m.export = newExport(m.palette, m.bundles, flattenGroups(m.aliasGroups))
 		return m, m.export.Init()
 	case screenQuit:
 		return m, tea.Quit
@@ -452,8 +519,11 @@ func (m Model) rehydrate() (tea.Model, tea.Cmd) {
 		}
 		m.progress = newProgressWithRunner(m.palette, m.bundles, m.selectedTools, runner)
 		return m, m.progress.Init()
+	case screenAliases:
+		m.aliases = newAliases(m.palette, m.aliasGroups, m.selectedAliases, m.aliasConflicts)
+		return m, m.aliases.Init()
 	case screenDone:
-		m.done = newDone(m.palette, m.bundles, m.selectedTools)
+		m.done = newDone(m.palette, m.bundles, m.selectedTools, resolveSelectedAliases(m.aliasGroups, m.selectedAliases))
 		return m, m.done.Init()
 	case screenBackupPrompt, screenBackupDone:
 		m.backup = newBackup(m.palette)
@@ -474,7 +544,7 @@ func (m Model) rehydrate() (tea.Model, tea.Cmd) {
 		m.info = newInfo(m.palette, m.info.bundleID, m.info.tool, m.infoPrev)
 		return m, m.info.Init()
 	case screenExport:
-		m.export = newExport(m.palette, m.bundles)
+		m.export = newExport(m.palette, m.bundles, flattenGroups(m.aliasGroups))
 		return m, m.export.Init()
 	}
 	return m, nil

--- a/internal/tui/config_input.go
+++ b/internal/tui/config_input.go
@@ -49,14 +49,20 @@ func (m configInputModel) Update(msg tea.Msg) (configInputModel, tea.Cmd) {
 				m.err = "enter a path or URL"
 				return m, nil
 			}
-			bundles, err := preset.Load(spec)
+			loaded, err := preset.Load(spec)
 			if err != nil {
 				m.err = err.Error()
 				return m, nil
 			}
 			m.err = ""
+			groups := preset.GroupAliases(preset.FilterAliasesForHost(loaded.Aliases))
 			return m, func() tea.Msg {
-				return transitionMsg{target: screenProbe, bundles: bundles}
+				return transitionMsg{
+					target:         screenProbe,
+					bundles:        preset.FilterForHost(loaded.Bundles),
+					aliasGroups:    groups,
+					replaceAliases: true,
+				}
 			}
 		}
 	}

--- a/internal/tui/done.go
+++ b/internal/tui/done.go
@@ -19,10 +19,23 @@ type doneModel struct {
 	palette  Palette
 	bundles  []preset.Bundle
 	selected map[string]bool
+	aliases  []preset.Alias
 }
 
-func newDone(p Palette, bundles []preset.Bundle, selected map[string]bool) doneModel {
-	return doneModel{palette: p, bundles: bundles, selected: selected}
+func newDone(p Palette, bundles []preset.Bundle, selected map[string]bool, aliases []preset.Alias) doneModel {
+	return doneModel{palette: p, bundles: bundles, selected: selected, aliases: aliases}
+}
+
+// hasReloadAlias reports whether the user picked the `reload` shortcut,
+// in which case the next-step "reload your shell" command can be the
+// short alias instead of the literal `exec bash`/`exec zsh`.
+func (m doneModel) hasReloadAlias() bool {
+	for _, a := range m.aliases {
+		if a.Name == "reload" {
+			return true
+		}
+	}
+	return false
 }
 
 func (m doneModel) Init() tea.Cmd { return nil }
@@ -57,6 +70,9 @@ func (m doneModel) View(width, height int) string {
 	b.WriteString("\n\n")
 
 	reload := reloadShellCmd()
+	if m.hasReloadAlias() {
+		reload = "reload"
+	}
 	steps := []struct{ cmd, desc string }{
 		{reload, "reload your shell (PATH updates already written to your rc)"},
 		{"lfg backup", "snapshot this machine"},
@@ -81,6 +97,25 @@ func (m doneModel) View(width, height int) string {
 		boxStyle := lipgloss.NewStyle().Foreground(p.Text).Background(p.Panel).Padding(0, 1)
 		for _, ev := range envs {
 			b.WriteString("  " + boxStyle.Render("export "+ev+"=...") + "\n")
+		}
+		b.WriteString("\n")
+	}
+
+	// Aliases section — only shown when the user picked at least one.
+	// Renders one line per alias with `name → expansion`, mirroring the
+	// env vars boxStyle so the section reads as a status report rather
+	// than something the user still has to act on.
+	if len(m.aliases) > 0 {
+		b.WriteString(SectionLabel(p, "Aliases configured",
+			fmt.Sprintf("written to your shell rc · %d total", len(m.aliases)), contentW))
+		b.WriteString("\n\n")
+		nameStyle := lipgloss.NewStyle().Foreground(p.Primary).Bold(true)
+		arrowStyle := lipgloss.NewStyle().Foreground(p.Muted)
+		cmdStyle := lipgloss.NewStyle().Foreground(p.Text)
+		for _, a := range m.aliases {
+			b.WriteString("  " + nameStyle.Render(fmt.Sprintf("%-7s", a.Name)) +
+				arrowStyle.Render("→  ") +
+				cmdStyle.Render(a.Command) + "\n")
 		}
 		b.WriteString("\n")
 	}

--- a/internal/tui/export.go
+++ b/internal/tui/export.go
@@ -19,15 +19,16 @@ import (
 // home directory; on submit calls preset.Save and shows a confirmation
 // with the full path.
 type exportModel struct {
-	palette  Palette
-	bundles  []preset.Bundle
-	input    textinput.Model
-	saved    bool
-	savedAt  string
-	err      string
+	palette Palette
+	bundles []preset.Bundle
+	aliases []preset.Alias
+	input   textinput.Model
+	saved   bool
+	savedAt string
+	err     string
 }
 
-func newExport(p Palette, bundles []preset.Bundle) exportModel {
+func newExport(p Palette, bundles []preset.Bundle, aliases []preset.Alias) exportModel {
 	ti := textinput.New()
 	ti.Prompt = "› "
 	ti.PromptStyle = lipgloss.NewStyle().Foreground(p.Primary).Bold(true)
@@ -44,7 +45,7 @@ func newExport(p Palette, bundles []preset.Bundle) exportModel {
 		ti.SetValue("lfg-preset.toml")
 	}
 	ti.Focus()
-	return exportModel{palette: p, bundles: bundles, input: ti}
+	return exportModel{palette: p, bundles: bundles, aliases: aliases, input: ti}
 }
 
 func (m exportModel) Init() tea.Cmd { return textinput.Blink }
@@ -65,7 +66,7 @@ func (m exportModel) Update(msg tea.Msg) (exportModel, tea.Cmd) {
 				m.err = "enter a file path"
 				return m, nil
 			}
-			if err := preset.Save(path, m.bundles); err != nil {
+			if err := preset.Save(path, m.bundles, m.aliases); err != nil {
 				m.err = err.Error()
 				return m, nil
 			}

--- a/internal/tui/probe.go
+++ b/internal/tui/probe.go
@@ -21,21 +21,23 @@ import (
 //
 // Lifecycle:
 //
-//  1. Init kicks off ProbeAllStream in a goroutine + arms the spinner +
-//     a "wait next probe step" cmd.
+//  1. Init kicks off ProbeAllStream + ProbeAliases in goroutines plus
+//     arms the spinner + "wait next probe step" cmd.
 //  2. Each probeStepMsg increments `done` and appends a log line.
 //  3. When the channel closes (probeDoneMsg), we apply the results onto
 //     the raw bundles, set the harness slice on the installer package,
-//     and emit a transitionMsg carrying the probed bundles to welcome.
+//     and emit a transitionMsg carrying the probed bundles + alias
+//     conflict map to welcome.
 type probeModel struct {
-	palette Palette
-	bundles []preset.Bundle // raw, pre-probe
-	spinner spinner.Model
-	bar     progress.Model
-	total   int
-	done    int
-	current string
-	results map[string]detect.Result
+	palette        Palette
+	bundles        []preset.Bundle // raw, pre-probe
+	spinner        spinner.Model
+	bar            progress.Model
+	total          int
+	done           int
+	current        string
+	results        map[string]detect.Result
+	aliasConflicts map[string]string
 
 	stream chan detect.ProbeStep
 }
@@ -44,6 +46,11 @@ type probeStepMsg detect.ProbeStep
 type probeDoneMsg struct {
 	bundles []preset.Bundle
 }
+
+// probeAliasesMsg carries the rc-alias conflict map back from the
+// goroutine that scans the user's shell rcs in parallel with detect.
+// Keyed by alias name → "<rc-basename>:<lineno>".
+type probeAliasesMsg map[string]string
 
 func newProbe(p Palette, bundles []preset.Bundle) probeModel {
 	sp := spinner.New()
@@ -74,7 +81,14 @@ func newProbe(p Palette, bundles []preset.Bundle) probeModel {
 
 func (m probeModel) Init() tea.Cmd {
 	go detect.ProbeAllStream(m.bundles, m.stream)
-	return tea.Batch(m.spinner.Tick, m.waitStep())
+	// Alias rc-scan runs in parallel with detect; it reads small files
+	// and finishes well before detect, but we want it to land as a
+	// message so the root model can stash conflicts before the alias
+	// screen mounts.
+	scanAliases := func() tea.Msg {
+		return probeAliasesMsg(detect.ProbeAliases())
+	}
+	return tea.Batch(m.spinner.Tick, m.waitStep(), scanAliases)
 }
 
 // waitStep returns a cmd that pulls one ProbeStep off the channel. When
@@ -106,11 +120,15 @@ func (m probeModel) Update(msg tea.Msg) (probeModel, tea.Cmd) {
 		m.current = step.Tool.Name
 		m.results[step.Key] = step.Result
 		return m, m.waitStep()
+	case probeAliasesMsg:
+		m.aliasConflicts = msg
+		return m, nil
 	case probeDoneMsg:
 		final := detect.Apply(m.bundles, m.results)
 		installer.SetHarnesses(detect.DetectedHarnesses())
+		conflicts := m.aliasConflicts
 		return m, func() tea.Msg {
-			return transitionMsg{target: screenWelcome, bundles: final}
+			return transitionMsg{target: screenWelcome, bundles: final, aliasConflicts: conflicts}
 		}
 	case tea.KeyMsg:
 		// Allow the user to skip the probe screen with Enter / Esc.
@@ -121,8 +139,9 @@ func (m probeModel) Update(msg tea.Msg) (probeModel, tea.Cmd) {
 		case "enter", "esc":
 			final := detect.Apply(m.bundles, m.results)
 			installer.SetHarnesses(detect.DetectedHarnesses())
+			conflicts := m.aliasConflicts
 			return m, func() tea.Msg {
-				return transitionMsg{target: screenWelcome, bundles: final}
+				return transitionMsg{target: screenWelcome, bundles: final, aliasConflicts: conflicts}
 			}
 		}
 	}

--- a/internal/tui/progress.go
+++ b/internal/tui/progress.go
@@ -258,7 +258,7 @@ func (m progressModel) Update(msg tea.Msg) (progressModel, tea.Cmd) {
 		return m, tea.Batch(
 			m.stopwatch.Stop(),
 			tea.Tick(800*time.Millisecond, func(time.Time) tea.Msg {
-				return transitionMsg{target: screenDone}
+				return transitionMsg{target: screenAliases}
 			}),
 		)
 	case progress.FrameMsg:
@@ -269,7 +269,7 @@ func (m progressModel) Update(msg tea.Msg) (progressModel, tea.Cmd) {
 		if m.awaitAck {
 			switch msg.String() {
 			case "enter", " ":
-				return m, goTo(screenDone)
+				return m, goTo(screenAliases)
 			case "esc":
 				return m, goTo(screenConfirm)
 			}

--- a/internal/tui/screens_test.go
+++ b/internal/tui/screens_test.go
@@ -194,6 +194,72 @@ func TestSnapshot_Probe(t *testing.T) {
 	}
 }
 
-// (TestNoControlCharsLeak removed — was a fragile heuristic for an old
-// huh-group-border bug. The redesign uses `│` legitimately as a separator
-// in header strips. Snapshot tests above already catch any visual drift.)
+// TestSnapshot_Aliases covers the alias picker — final optional screen
+// before the done card. Bypasses driveAndSnapshot because reaching the
+// alias screen via real key input would require driving the whole
+// install flow (slow, brittle): we construct aliasesModel directly with
+// the default catalog, then render.
+func TestSnapshot_Aliases(t *testing.T) {
+	for _, sz := range sizes {
+		name := "aliases_lfg_" + sz.name
+		t.Run(name, func(t *testing.T) {
+			pal := PaletteFor(ThemeLFG)
+			m := newAliases(pal, preset.DefaultAliases(), nil, nil)
+			pumpAliasesInit(&m)
+			renderGolden(t, name, m.View(sz.w, sz.h))
+		})
+	}
+}
+
+// TestSnapshot_AliasesConflict locks in the rendering of the conflict
+// warning suffix on alias options whose names already exist in the
+// user's rc files outside the lfg-managed block.
+func TestSnapshot_AliasesConflict(t *testing.T) {
+	sz := termSize{"md_100x30", 100, 30}
+	name := "aliases_conflict_lfg_" + sz.name
+	t.Run(name, func(t *testing.T) {
+		pal := PaletteFor(ThemeLFG)
+		conflicts := map[string]string{
+			"gd": ".zshrc:42",
+			"gs": ".bashrc:17",
+		}
+		m := newAliases(pal, preset.DefaultAliases(), nil, conflicts)
+		pumpAliasesInit(&m)
+		renderGolden(t, name, m.View(sz.w, sz.h))
+	})
+}
+
+// pumpAliasesInit fires the form's Init() command so huh's MultiSelect
+// transitions out of its uninitialized "blank canvas" state and the
+// option list actually renders for the snapshot. Without this every
+// golden contains an empty form area.
+func pumpAliasesInit(m *aliasesModel) {
+	if cmd := m.Init(); cmd != nil {
+		if msg := cmd(); msg != nil {
+			updated, _ := m.Update(msg)
+			*m = updated
+		}
+	}
+}
+
+func renderGolden(t *testing.T, name, got string) {
+	t.Helper()
+	goldenPath := filepath.Join("testdata", name+".golden")
+	if *updateGolden {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(goldenPath, []byte(got), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("wrote %s (%d lines)", goldenPath, strings.Count(got, "\n"))
+		return
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("missing golden %s — run `go test ./internal/tui -update` first: %v", goldenPath, err)
+	}
+	if got != string(want) {
+		t.Errorf("snapshot diff for %s\n--- want\n%s\n--- got\n%s", name, want, got)
+	}
+}

--- a/internal/tui/testdata/aliases_conflict_lfg_md_100x30.golden
+++ b/internal/tui/testdata/aliases_conflict_lfg_md_100x30.golden
@@ -1,0 +1,30 @@
+                                                                                                    
+  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓  
+  ┃  ▌ lfg │ STEP 4 · ALIASES                                                         THEME LFG  ┃  
+  ┃──────────────────────────────────────────────────────────────────────────────────────────────┃  
+  ┃                                                                                              ┃  
+  ┃┃ SHELL ALIASES                                                OPTIONAL · WRITTEN TO YOUR RC  ┃  
+  ┃                                                                                              ┃  
+  ┃  Quality-of-life shortcuts. We write a fenced block to every detected                        ┃  
+  ┃  shell rc; deselecting all leaves your rc unchanged.                                         ┃  
+  ┃                                                                                              ┃  
+  ┃  ⚠ some names already defined in your rc — selecting will shadow the existing alias          ┃  
+  ┃                                                                                              ┃  
+  ┃Pick shell aliases                                                                            ┃  
+  ┃Selected aliases get added to a fenced lfg-managed block in your shell rc(s).                 ┃  
+  ┃You can re-run lfg anytime to change selection.                                               ┃  
+  ┃> ✓ gd      checkout develop + pull  ⚠ in .zshrc:42                                           ┃  
+  ┃  ✓ gf      fetch all remotes, prune                                                          ┃  
+  ┃  ✓ gs      git status  ⚠ in .bashrc:17                                                       ┃  
+  ┃  ✓ gp      git push                                                                          ┃  
+  ┃  ✓ gl      compact recent log                                                                ┃  
+  ┃  ✓ gco     git checkout                                                                      ┃  
+  ┃  ✓ c       claude (normal mode)                                                              ┃  
+  ┃  ✓ cr      claude resume                                                                     ┃  
+  ┃  ✓ cw      claude worktree                                                                   ┃  
+  ┃                                                                                              ┃  
+  ┃──────────────────────────────────────────────────────────────────────────────────────────────┃  
+  ┃  [x] TOGGLE  [⏎] CONTINUE  [^S] SUBMIT NOW  [ESC] SKIP                                       ┃  
+  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛  
+                                                                                                    
+                                                                                                    

--- a/internal/tui/testdata/aliases_lfg_lg_120x36.golden
+++ b/internal/tui/testdata/aliases_lfg_lg_120x36.golden
@@ -1,0 +1,36 @@
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+          ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓          
+          ┃  ▌ lfg │ STEP 4 · ALIASES                                                             THEME LFG  ┃          
+          ┃──────────────────────────────────────────────────────────────────────────────────────────────────┃          
+          ┃                                                                                                  ┃          
+          ┃┃ SHELL ALIASES                                                    OPTIONAL · WRITTEN TO YOUR RC  ┃          
+          ┃                                                                                                  ┃          
+          ┃  Quality-of-life shortcuts. We write a fenced block to every detected                            ┃          
+          ┃  shell rc; deselecting all leaves your rc unchanged.                                             ┃          
+          ┃                                                                                                  ┃          
+          ┃Pick shell aliases                                                                                ┃          
+          ┃Selected aliases get added to a fenced lfg-managed block in your shell rc(s).                     ┃          
+          ┃You can re-run lfg anytime to change selection.                                                   ┃          
+          ┃> ✓ gd      checkout develop + pull                                                               ┃          
+          ┃  ✓ gf      fetch all remotes, prune                                                              ┃          
+          ┃  ✓ gs      git status                                                                            ┃          
+          ┃  ✓ gp      git push                                                                              ┃          
+          ┃  ✓ gl      compact recent log                                                                    ┃          
+          ┃  ✓ gco     git checkout                                                                          ┃          
+          ┃  ✓ c       claude (normal mode)                                                                  ┃          
+          ┃  ✓ cr      claude resume                                                                         ┃          
+          ┃  ✓ cw      claude worktree                                                                       ┃          
+          ┃                                                                                                  ┃          
+          ┃──────────────────────────────────────────────────────────────────────────────────────────────────┃          
+          ┃  [x] TOGGLE  [⏎] CONTINUE  [^S] SUBMIT NOW  [ESC] SKIP                                           ┃          
+          ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛          
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        
+                                                                                                                        

--- a/internal/tui/testdata/aliases_lfg_md_100x30.golden
+++ b/internal/tui/testdata/aliases_lfg_md_100x30.golden
@@ -1,0 +1,30 @@
+                                                                                                    
+                                                                                                    
+  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓  
+  ┃  ▌ lfg │ STEP 4 · ALIASES                                                         THEME LFG  ┃  
+  ┃──────────────────────────────────────────────────────────────────────────────────────────────┃  
+  ┃                                                                                              ┃  
+  ┃┃ SHELL ALIASES                                                OPTIONAL · WRITTEN TO YOUR RC  ┃  
+  ┃                                                                                              ┃  
+  ┃  Quality-of-life shortcuts. We write a fenced block to every detected                        ┃  
+  ┃  shell rc; deselecting all leaves your rc unchanged.                                         ┃  
+  ┃                                                                                              ┃  
+  ┃Pick shell aliases                                                                            ┃  
+  ┃Selected aliases get added to a fenced lfg-managed block in your shell rc(s).                 ┃  
+  ┃You can re-run lfg anytime to change selection.                                               ┃  
+  ┃> ✓ gd      checkout develop + pull                                                           ┃  
+  ┃  ✓ gf      fetch all remotes, prune                                                          ┃  
+  ┃  ✓ gs      git status                                                                        ┃  
+  ┃  ✓ gp      git push                                                                          ┃  
+  ┃  ✓ gl      compact recent log                                                                ┃  
+  ┃  ✓ gco     git checkout                                                                      ┃  
+  ┃  ✓ c       claude (normal mode)                                                              ┃  
+  ┃  ✓ cr      claude resume                                                                     ┃  
+  ┃  ✓ cw      claude worktree                                                                   ┃  
+  ┃                                                                                              ┃  
+  ┃──────────────────────────────────────────────────────────────────────────────────────────────┃  
+  ┃  [x] TOGGLE  [⏎] CONTINUE  [^S] SUBMIT NOW  [ESC] SKIP                                       ┃  
+  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛  
+                                                                                                    
+                                                                                                    
+                                                                                                    

--- a/internal/tui/testdata/aliases_lfg_sm_80x24.golden
+++ b/internal/tui/testdata/aliases_lfg_sm_80x24.golden
@@ -1,0 +1,25 @@
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃  ▌ lfg │ STEP 4 · ALIASES                                     THEME LFG  ┃
+┃──────────────────────────────────────────────────────────────────────────┃
+┃                                                                          ┃
+┃┃ SHELL ALIASES                            OPTIONAL · WRITTEN TO YOUR RC  ┃
+┃                                                                          ┃
+┃  Quality-of-life shortcuts. We write a fenced block to every detected    ┃
+┃  shell rc; deselecting all leaves your rc unchanged.                     ┃
+┃                                                                          ┃
+┃Pick shell aliases                                                              ┃
+┃Selected aliases get added to a fenced lfg-managed block in your shell rc(s).   ┃
+┃You can re-run lfg anytime to change selection.                                 ┃
+┃> ✓ gd      checkout develop + pull                                             ┃
+┃  ✓ gf      fetch all remotes, prune                                            ┃
+┃  ✓ gs      git status                                                          ┃
+┃  ✓ gp      git push                                                            ┃
+┃  ✓ gl      compact recent log                                                  ┃
+┃  ✓ gco     git checkout                                                        ┃
+┃  ✓ c       claude (normal mode)                                                ┃
+┃  ✓ cr      claude resume                                                       ┃
+┃  ✓ cw      claude worktree                                                    ┃
+┃                                                                          ┃
+┃──────────────────────────────────────────────────────────────────────────┃
+┃  [x] TOGGLE  [⏎] CONTINUE  [^S] SUBMIT NOW  [ESC] SKIP                   ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

--- a/internal/tui/testdata/aliases_lfg_xl_160x44.golden
+++ b/internal/tui/testdata/aliases_lfg_xl_160x44.golden
@@ -1,0 +1,44 @@
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                              ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓                              
+                              ┃  ▌ lfg │ STEP 4 · ALIASES                                                             THEME LFG  ┃                              
+                              ┃──────────────────────────────────────────────────────────────────────────────────────────────────┃                              
+                              ┃                                                                                                  ┃                              
+                              ┃┃ SHELL ALIASES                                                    OPTIONAL · WRITTEN TO YOUR RC  ┃                              
+                              ┃                                                                                                  ┃                              
+                              ┃  Quality-of-life shortcuts. We write a fenced block to every detected                            ┃                              
+                              ┃  shell rc; deselecting all leaves your rc unchanged.                                             ┃                              
+                              ┃                                                                                                  ┃                              
+                              ┃Pick shell aliases                                                                                ┃                              
+                              ┃Selected aliases get added to a fenced lfg-managed block in your shell rc(s).                     ┃                              
+                              ┃You can re-run lfg anytime to change selection.                                                   ┃                              
+                              ┃> ✓ gd      checkout develop + pull                                                               ┃                              
+                              ┃  ✓ gf      fetch all remotes, prune                                                              ┃                              
+                              ┃  ✓ gs      git status                                                                            ┃                              
+                              ┃  ✓ gp      git push                                                                              ┃                              
+                              ┃  ✓ gl      compact recent log                                                                    ┃                              
+                              ┃  ✓ gco     git checkout                                                                          ┃                              
+                              ┃  ✓ c       claude (normal mode)                                                                  ┃                              
+                              ┃  ✓ cr      claude resume                                                                         ┃                              
+                              ┃  ✓ cw      claude worktree                                                                       ┃                              
+                              ┃                                                                                                  ┃                              
+                              ┃──────────────────────────────────────────────────────────────────────────────────────────────────┃                              
+                              ┃  [x] TOGGLE  [⏎] CONTINUE  [^S] SUBMIT NOW  [ESC] SKIP                                           ┃                              
+                              ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛                              
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                
+                                                                                                                                                                

--- a/internal/tui/testdata/aliases_lfg_xs_60x20.golden
+++ b/internal/tui/testdata/aliases_lfg_xs_60x20.golden
@@ -1,0 +1,25 @@
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃  ▌ lfg │ STEP 4 · ALIASES                 THEME LFG  ┃
+┃──────────────────────────────────────────────────────┃
+┃                                                      ┃
+┃┃ SHELL ALIASES        OPTIONAL · WRITTEN TO YOUR RC  ┃
+┃                                                      ┃
+┃  Quality-of-life shortcuts. We write a fenced block to every detected┃
+┃  shell rc; deselecting all leaves your rc unchanged.                 ┃
+┃                                                      ┃
+┃Pick shell aliases                                                              ┃
+┃Selected aliases get added to a fenced lfg-managed block in your shell rc(s).   ┃
+┃You can re-run lfg anytime to change selection.                                 ┃
+┃> ✓ gd      checkout develop + pull                                             ┃
+┃  ✓ gf      fetch all remotes, prune                                            ┃
+┃  ✓ gs      git status                                                          ┃
+┃  ✓ gp      git push                                                            ┃
+┃  ✓ gl      compact recent log                                                  ┃
+┃  ✓ gco     git checkout                                                        ┃
+┃  ✓ c       claude (normal mode)                                                ┃
+┃  ✓ cr      claude resume                                                       ┃
+┃  ✓ cw      claude worktree                                                    ┃
+┃                                                      ┃
+┃──────────────────────────────────────────────────────┃
+┃  [x] TOGGLE  [⏎] CONTINUE  [^S] SUBMIT NOW  [ESC] SKIP┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

--- a/internal/tui/testdata/aliases_lfg_xxl_200x50.golden
+++ b/internal/tui/testdata/aliases_lfg_xxl_200x50.golden
@@ -1,0 +1,50 @@
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓                                                  
+                                                  ┃  ▌ lfg │ STEP 4 · ALIASES                                                             THEME LFG  ┃                                                  
+                                                  ┃──────────────────────────────────────────────────────────────────────────────────────────────────┃                                                  
+                                                  ┃                                                                                                  ┃                                                  
+                                                  ┃┃ SHELL ALIASES                                                    OPTIONAL · WRITTEN TO YOUR RC  ┃                                                  
+                                                  ┃                                                                                                  ┃                                                  
+                                                  ┃  Quality-of-life shortcuts. We write a fenced block to every detected                            ┃                                                  
+                                                  ┃  shell rc; deselecting all leaves your rc unchanged.                                             ┃                                                  
+                                                  ┃                                                                                                  ┃                                                  
+                                                  ┃Pick shell aliases                                                                                ┃                                                  
+                                                  ┃Selected aliases get added to a fenced lfg-managed block in your shell rc(s).                     ┃                                                  
+                                                  ┃You can re-run lfg anytime to change selection.                                                   ┃                                                  
+                                                  ┃> ✓ gd      checkout develop + pull                                                               ┃                                                  
+                                                  ┃  ✓ gf      fetch all remotes, prune                                                              ┃                                                  
+                                                  ┃  ✓ gs      git status                                                                            ┃                                                  
+                                                  ┃  ✓ gp      git push                                                                              ┃                                                  
+                                                  ┃  ✓ gl      compact recent log                                                                    ┃                                                  
+                                                  ┃  ✓ gco     git checkout                                                                          ┃                                                  
+                                                  ┃  ✓ c       claude (normal mode)                                                                  ┃                                                  
+                                                  ┃  ✓ cr      claude resume                                                                         ┃                                                  
+                                                  ┃  ✓ cw      claude worktree                                                                       ┃                                                  
+                                                  ┃                                                                                                  ┃                                                  
+                                                  ┃──────────────────────────────────────────────────────────────────────────────────────────────────┃                                                  
+                                                  ┃  [x] TOGGLE  [⏎] CONTINUE  [^S] SUBMIT NOW  [ESC] SKIP                                           ┃                                                  
+                                                  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛                                                  
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        
+                                                                                                                                                                                                        


### PR DESCRIPTION
## Summary

- New optional alias picker between install progress and done. Selected aliases get written to a fenced `# lfg-managed aliases` block in every detected shell rc (bash/zsh/fish), sibling to the existing PATH block.
- `--config` is source of truth: a config-file `[[aliases]]` table replaces the built-in catalog (REPLACE semantics matching bundles). Missing table → picker hidden.
- Probe phase greps user rcs for pre-existing `alias NAME=...` outside the lfg block and surfaces conflicts in the picker as `gd ⚠ in .zshrc:42` warnings.

## Catalog

| Group | Aliases |
|------|--------|
| git | `gd` `gf` `gs` `gp` `gl` `gco` |
| claude | `c` `cr` `cw` |
| shell | `reload` |

`reload` is per-shell special-cased: `alias reload='exec bash'` (or zsh) on POSIX shells, `function reload; exec fish; end` on fish. Empty selection strips the block in place — no orphan markers.

## Test plan

- [x] `make build` clean
- [x] `make test` clean (existing snapshots untouched, 7 new alias goldens land)
- [x] Unit tests: posix-quote escaping, per-shell render (bash/zsh/fish), idempotent upsert, empty-list strips block, `ExistingAliases` skips managed block + surfaces user-owned aliases before/after
- [ ] Walk full TUI end-to-end (`./lfg`) — exercise alias picker, deselect-all path, conflict warnings
- [ ] `./lfg --config testdata/sample-aliases.toml` — confirm picker shows config aliases only
- [ ] `./lfg export` round-trip → TOML contains `[[aliases]]`
- [ ] `make docker-test` confirms bash rc detection in container

🤖 Generated with [Claude Code](https://claude.com/claude-code)