### PR TITLE
ci: add workflow_dispatch fallback to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.4.0). Must already exist."
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -23,6 +29,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
           fetch-depth: 0
 
       - name: set up go


### PR DESCRIPTION
## Summary

- Adds a manual `workflow_dispatch` trigger to release.yml so we can re-run goreleaser against an existing tag without the delete-and-repush dance.
- Fixes the silent failure mode hit during the v0.4.0 stable cut: release-please's `GITHUB_TOKEN`-pushed tag did NOT fire `release.yml` (GitHub's anti-recursion safeguard for `GITHUB_TOKEN`-driven cascades), so the GitHub Release sat with 0 assets and the tap formula never bumped.
- Checkout step now branches between `push.ref` (auto) and the dispatch input so both paths land on the right tag.

## Trigger from CLI

```
gh workflow run release.yml -f tag=v0.4.1
```

## Followup options (not in this PR)

- Swap `secrets.GITHUB_TOKEN` for a PAT in release-please.yml so future tag pushes auto-trigger release.yml without needing the dispatch fallback.

## Test plan

- [ ] Merge to develop → main → tag a beta (`v0.4.1-beta.0`) and confirm push trigger still works
- [ ] If next stable release-please run hits the same race, verify `gh workflow run release.yml -f tag=vX.Y.Z` publishes binaries + tap formula

🤖 Generated with [Claude Code](https://claude.com/claude-code)